### PR TITLE
Generate exports keys

### DIFF
--- a/.changeset/gentle-wombats-collect.md
+++ b/.changeset/gentle-wombats-collect.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': minor
+---
+
+The ESM compliant `exports` key is now checked as part of package.json validation

--- a/fixtures/monorepo/packages/multi-entry-library/package.json
+++ b/fixtures/monorepo/packages/multi-entry-library/package.json
@@ -2,8 +2,8 @@
   "name": "@crackle-fixtures/multi-entry-library",
   "version": "1.0.0",
   "private": true,
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "files": [
     "/components",
     "/dist",
@@ -26,5 +26,38 @@
     "package": "crackle package",
     "serve": "crackle serve",
     "start": "crackle start"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/index.cjs.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.cjs.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    },
+    "./components": {
+      "import": {
+        "types": "./components/index.cjs.d.ts",
+        "default": "./components/index.mjs"
+      },
+      "require": {
+        "types": "./components/index.cjs.d.ts",
+        "default": "./components/index.cjs"
+      }
+    },
+    "./extras": {
+      "import": {
+        "types": "./extras/index.cjs.d.ts",
+        "default": "./extras/index.mjs"
+      },
+      "require": {
+        "types": "./extras/index.cjs.d.ts",
+        "default": "./extras/index.cjs"
+      }
+    }
   }
 }

--- a/fixtures/monorepo/packages/single-entry-library/package.json
+++ b/fixtures/monorepo/packages/single-entry-library/package.json
@@ -2,8 +2,8 @@
   "name": "@crackle-fixtures/single-entry-library",
   "version": "1.0.0",
   "private": true,
-  "main": "dist/index.cjs.js",
-  "module": "dist/index.esm.js",
+  "main": "dist/index.cjs",
+  "module": "dist/index.mjs",
   "files": [
     "/dist"
   ],
@@ -24,5 +24,18 @@
     "package": "crackle package",
     "serve": "crackle serve",
     "start": "crackle start"
+  },
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "import": {
+        "types": "./dist/index.cjs.d.ts",
+        "default": "./dist/index.mjs"
+      },
+      "require": {
+        "types": "./dist/index.cjs.d.ts",
+        "default": "./dist/index.cjs"
+      }
+    }
   }
 }

--- a/packages/core/src/reporters/fix/components/Diff.tsx
+++ b/packages/core/src/reporters/fix/components/Diff.tsx
@@ -5,6 +5,10 @@ import React from 'react';
 import type { Difference } from '../../../utils/setup-package-json';
 
 export const Diff = ({ diff }: { diff: Difference }) => {
+  if (diff.key === 'exports') {
+    return <Text>- exports key updated</Text>;
+  }
+
   if (diff.key === 'files') {
     const missingFiles = diff.additions.map((addition) => (
       <Text key={addition} color="blueBright">

--- a/packages/core/src/reporters/shared/Errors.tsx
+++ b/packages/core/src/reporters/shared/Errors.tsx
@@ -64,6 +64,10 @@ const Diff = ({ diff }: { diff: Difference }) => {
     return <Text>- "files" is missing {missingFiles}</Text>;
   }
 
+  if (diff.key === 'exports') {
+    return <Text>- The "exports" key is incorrect</Text>;
+  }
+
   if (diff.from && !diff.to) {
     return (
       <Text>

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -26,8 +26,19 @@ export interface CrackleServer {
   close: () => Promise<void>;
 }
 
-export interface PackageEntryPoint {
+interface DefaultPackageEntryPoint {
+  isDefaultEntry: true;
   entryPath: string;
   outputDir: string;
-  isDefaultEntry: boolean;
 }
+
+interface OtherPackageEntryPoint {
+  isDefaultEntry: false;
+  entryPath: string;
+  outputDir: string;
+  entryName: string;
+}
+
+export type PackageEntryPoint =
+  | DefaultPackageEntryPoint
+  | OtherPackageEntryPoint;

--- a/packages/core/src/utils/get-packages.ts
+++ b/packages/core/src/utils/get-packages.ts
@@ -59,10 +59,10 @@ export const getPackageEntryPoints = async ({
 
   return entryPaths.map((entryPath) => {
     const isDefaultEntry = entryPath.includes('src/index.ts');
-    const outputLocalPath = isDefaultEntry ? 'dist' : basename(entryPath);
+    const entryName = isDefaultEntry ? 'dist' : basename(entryPath);
 
-    const outputDir = path.join(packageRoot, outputLocalPath);
+    const outputDir = path.join(packageRoot, entryName);
 
-    return { entryPath, outputDir, isDefaultEntry };
+    return { entryPath, outputDir, isDefaultEntry, entryName };
   });
 };

--- a/packages/core/src/utils/setup-package-json.ts
+++ b/packages/core/src/utils/setup-package-json.ts
@@ -1,5 +1,6 @@
 import fs from 'fs/promises';
 import path from 'path';
+import { isDeepStrictEqual } from 'util';
 
 import type { PackageEntryPoint } from '../types';
 
@@ -8,7 +9,48 @@ import { writeFile } from './write-file';
 
 type FromToDifference = { key: 'main' | 'module'; from?: string; to?: string };
 type AdditionsDifference = { key: 'files'; additions: string[] };
-export type Difference = FromToDifference | AdditionsDifference;
+type ExportsDifference = { key: 'exports' };
+export type Difference =
+  | FromToDifference
+  | AdditionsDifference
+  | ExportsDifference;
+
+type ExportString = `./${string}`;
+
+type ExportWithTypes = {
+  types: ExportString;
+  default: ExportString;
+};
+
+type ExportObject = {
+  import: ExportWithTypes;
+  require: ExportWithTypes;
+};
+
+const getExportsForPackage = (entries: PackageEntryPoint[]) => {
+  const exports: Record<string, ExportString | ExportObject> = {
+    './package.json': './package.json',
+  };
+
+  for (const entryPoint of entries) {
+    if (entryPoint.isDefaultEntry) {
+      const types = './dist/index.cjs.d.ts';
+      exports['.'] = {
+        import: { types, default: './dist/index.mjs' },
+        require: { types, default: './dist/index.cjs' },
+      };
+      continue;
+    }
+
+    const types = `./${entryPoint.entryName}/index.cjs.d.ts` as const;
+    exports[`./${entryPoint.entryName}`] = {
+      import: { types, default: `./${entryPoint.entryName}/index.mjs` },
+      require: { types, default: `./${entryPoint.entryName}/index.cjs` },
+    };
+  }
+
+  return exports;
+};
 
 const setupPackageJson =
   (write: boolean) =>
@@ -26,14 +68,16 @@ const setupPackageJson =
 
     for (const entryPoint of entries) {
       if (entryPoint.isDefaultEntry) {
-        main = 'dist/index.cjs.js';
-        module = 'dist/index.esm.js';
+        main = 'dist/index.cjs';
+        module = 'dist/index.mjs';
         files.add('/dist');
       } else {
         const entryName = basename(entryPoint.entryPath);
         files.add(`/${entryName}`);
       }
     }
+
+    const exportsKey = getExportsForPackage(entries);
 
     const filesArray = Array.from(files);
     const diffs: Difference[] = [];
@@ -61,18 +105,23 @@ const setupPackageJson =
       diffs.push({ key: 'files', additions: missingFiles });
     }
 
-    if (diffs.length > 0) {
+    const packageJsonExports = packageJson.exports;
+
+    if (!isDeepStrictEqual(packageJsonExports, exportsKey)) {
+      diffs.push({ key: 'exports' });
+    }
+
+    if (write && diffs.length > 0) {
       packageJson.main = main;
       packageJson.module = module;
       packageJson.files = filesArray.sort((a, b) => (a > b ? 1 : -1));
+      packageJson.exports = exportsKey;
 
-      if (write) {
-        await writeFile({
-          dir: packageRoot,
-          fileName: 'package.json',
-          contents: JSON.stringify(packageJson, null, 2).concat('\n'),
-        });
-      }
+      await writeFile({
+        dir: packageRoot,
+        fileName: 'package.json',
+        contents: JSON.stringify(packageJson, null, 2).concat('\n'),
+      });
     }
 
     return diffs;


### PR DESCRIPTION
Changes here:
- JS build artefacts now use the cjs/mjs extensions so Node knows what's what
- `crackle package` checks for that exports key as part of the package.json validation
  - `crackle fix` can now add it as well
- The fixtures now use the new build output and exports key.

This means that packages generated by crackle will be fully ESM compliant, using the exports key in package.json, while still maintaining the preconstruct directory structure that enables subdir imports for CJS.