### PR TITLE
Remove `ignore` from changeset config

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -6,7 +6,6 @@
   "access": "public",
   "baseBranch": "master",
   "updateInternalDependencies": "patch",
-  "ignore": ["@crackle-fixtures/*"],
   "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
     "updateInternalDependents": "always"
   }


### PR DESCRIPTION
This line is failing validation when CI tries to read the changeset config. https://github.com/seek-oss/crackle/runs/8242111413?check_suite_focus=true#step:6:20