### PR TITLE
Bump pnpm action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,13 +12,13 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: pnpm/action-setup@v2.2.2
-
       - name: Checkout Repo
         uses: actions/checkout@main
         with:
           fetch-depth: 0
           token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@v2.2.2
 
       - name: Setup Node.js
         uses: actions/setup-node@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2
 
       - name: Setup Node.js
         uses: actions/setup-node@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v2.2.2
         with:
           version: 7.9.5
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,6 @@ jobs:
       CI: true
     steps:
       - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.9.5
 
       - name: Checkout Repo
         uses: actions/checkout@main

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,14 +8,14 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: pnpm/action-setup@v2.2.2
-
       - name: Checkout Repo
         uses: actions/checkout@main
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
           token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@v2.2.2
 
       - name: Setup Node.js
         uses: actions/setup-node@main

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -9,8 +9,6 @@ jobs:
       CI: true
     steps:
       - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.9.5
 
       - name: Checkout Repo
         uses: actions/checkout@main

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -8,7 +8,7 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v2.2.2
         with:
           version: 7.9.5
 

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2
 
       - name: Setup Node.js
         uses: actions/setup-node@main

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,7 +9,7 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: pnpm/action-setup@v2.0.1
+      - uses: pnpm/action-setup@v2.2.2
         with:
           version: 7.9.5
 

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,13 +9,13 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: pnpm/action-setup@v2.2.2
-
       - name: Checkout Repo
         uses: actions/checkout@main
         with:
           fetch-depth: 0
           token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
+
+      - uses: pnpm/action-setup@v2.2.2
 
       - name: Setup Node.js
         uses: actions/setup-node@main

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -10,8 +10,6 @@ jobs:
       CI: true
     steps:
       - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.9.5
 
       - name: Checkout Repo
         uses: actions/checkout@main

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@v2.2.2
+      - uses: pnpm/action-setup@v2
 
       - name: Setup Node.js
         uses: actions/setup-node@main

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
   "volta": {
     "node": "16.16.0"
   },
+  "packageManager": "pnpm@7.9.5",
   "devDependencies": {
     "@changesets/changelog-github": "^0.4.6",
     "@preconstruct/eslint-plugin-format-js-tag": "^0.2.0",


### PR DESCRIPTION
- 2.1.0 [supports pnpm 7](https://github.com/pnpm/action-setup/pull/29)
- 2.2.0 [supports the `packageManager` field](https://github.com/pnpm/action-setup/pull/33) so no need to specify the version manually