### PR TITLE
Several fixes for `.d.ts` bundle generation

### DIFF
--- a/.changeset/neat-worms-press.md
+++ b/.changeset/neat-worms-press.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': minor
+---
+
+Add a `clean` config option to clean the output directory on `crackle package`

--- a/.changeset/purple-pumpkins-build.md
+++ b/.changeset/purple-pumpkins-build.md
@@ -2,4 +2,4 @@
 '@crackle/cli': minor
 ---
 
-Add a `--clean` option for `crackle package` to clean the output directory
+Add a `--clean` CLI argument for `crackle package` to clean the output directory

--- a/.changeset/purple-pumpkins-build.md
+++ b/.changeset/purple-pumpkins-build.md
@@ -1,0 +1,5 @@
+---
+'@crackle/cli': minor
+---
+
+Add a `--clean` option for `crackle package` to clean the output directory

--- a/.changeset/ten-swans-wink.md
+++ b/.changeset/ten-swans-wink.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': patch
+---
+
+Add an option to override `compilerOptions` for `.d.ts` bundle generation

--- a/.changeset/ten-swans-wink.md
+++ b/.changeset/ten-swans-wink.md
@@ -1,5 +1,0 @@
----
-'@crackle/core': patch
----
-
-Add an option to override `compilerOptions` for `.d.ts` bundle generation

--- a/.changeset/violet-berries-wonder.md
+++ b/.changeset/violet-berries-wonder.md
@@ -2,4 +2,4 @@
 '@crackle/core': minor
 ---
 
-Added a `dtsOptions` config option to override the default TypeScript `compilerOptions` for `.d.ts` bundle generation
+Add a `dtsOptions` config option to override the default TypeScript `compilerOptions` for `.d.ts` bundle generation

--- a/.changeset/violet-berries-wonder.md
+++ b/.changeset/violet-berries-wonder.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': minor
+---
+
+Added a `dtsOptions` config option to override the default TypeScript `compilerOptions` for `.d.ts` bundle generation

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -33,7 +33,7 @@ jobs:
           pnpm build
 
       - name: Set up fixtures
-        run: pnpm dev-fixtures
+        run: pnpm fixtures dev
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -32,7 +32,7 @@ jobs:
           pnpm fix
           pnpm build
 
-      - name: Setup fixtures
+      - name: Set up fixtures
         run: pnpm dev-fixtures
 
       - name: Lint

--- a/fixtures/braid-site/package.json
+++ b/fixtures/braid-site/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@crackle/router": "workspace:*",
     "@vanilla-extract/css": "^1.7.3",
-    "braid-design-system": "0.0.0-crackel2-20220901020334",
+    "braid-design-system": "0.0.0-crackel2-20220919072731",
     "react": "17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/fixtures/library-with-docs/package.json
+++ b/fixtures/library-with-docs/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "@crackle/router": "workspace:*",
     "@vanilla-extract/css": "^1.7.3",
-    "braid-design-system": "0.0.0-crackel2-20220901020334",
+    "braid-design-system": "0.0.0-crackel2-20220919072731",
     "react": "17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/fixtures/library-with-docs/package.json
+++ b/fixtures/library-with-docs/package.json
@@ -4,7 +4,19 @@
   "private": true,
   "license": "MIT",
   "author": "Ben",
-  "main": "dist/index.js",
+  "exports": {
+    "./package.json": "./package.json",
+    ".": {
+      "types": "./dist/index.cjs.d.ts",
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs"
+    }
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.esm.js",
+  "files": [
+    "/dist"
+  ],
   "scripts": {
     "build": "crackle build",
     "dev": "crackle dev",

--- a/fixtures/multi-entry-library/package.json
+++ b/fixtures/multi-entry-library/package.json
@@ -9,7 +9,7 @@
     ".": {
       "import": {
         "types": "./dist/index.cjs.d.ts",
-        "default": "./dist/index.mjs"
+        "default": "./dist/index.esm.js"
       },
       "require": {
         "types": "./dist/index.cjs.d.ts",
@@ -18,37 +18,37 @@
     },
     "./components": {
       "import": {
-        "types": "./components/index.cjs.d.ts",
-        "default": "./components/index.mjs"
+        "types": "./components/dist/index.cjs.d.ts",
+        "default": "./components/dist/index.esm.js"
       },
       "require": {
-        "types": "./components/index.cjs.d.ts",
-        "default": "./components/index.cjs"
+        "types": "./components/dist/index.cjs.d.ts",
+        "default": "./components/dist/index.cjs"
       }
     },
     "./extras": {
       "import": {
-        "types": "./extras/index.cjs.d.ts",
-        "default": "./extras/index.mjs"
+        "types": "./extras/dist/index.cjs.d.ts",
+        "default": "./extras/dist/index.esm.js"
       },
       "require": {
-        "types": "./extras/index.cjs.d.ts",
-        "default": "./extras/index.cjs"
+        "types": "./extras/dist/index.cjs.d.ts",
+        "default": "./extras/dist/index.cjs"
       }
     },
     "./themes/apac": {
       "import": {
-        "types": "./themes/apac/index.cjs.d.ts",
-        "default": "./themes/apac/index.mjs"
+        "types": "./themes/apac/dist/index.cjs.d.ts",
+        "default": "./themes/apac/dist/index.esm.js"
       },
       "require": {
-        "types": "./themes/apac/index.cjs.d.ts",
-        "default": "./themes/apac/index.cjs"
+        "types": "./themes/apac/dist/index.cjs.d.ts",
+        "default": "./themes/apac/dist/index.cjs"
       }
     }
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.esm.js",
   "files": [
     "/components",
     "/dist",

--- a/fixtures/multi-entry-library/package.json
+++ b/fixtures/multi-entry-library/package.json
@@ -7,44 +7,24 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": {
-        "types": "./dist/index.cjs.d.ts",
-        "default": "./dist/index.esm.js"
-      },
-      "require": {
-        "types": "./dist/index.cjs.d.ts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.cjs.d.ts",
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs"
     },
     "./components": {
-      "import": {
-        "types": "./components/dist/index.cjs.d.ts",
-        "default": "./components/dist/index.esm.js"
-      },
-      "require": {
-        "types": "./components/dist/index.cjs.d.ts",
-        "default": "./components/dist/index.cjs"
-      }
+      "types": "./components/dist/index.cjs.d.ts",
+      "import": "./components/dist/index.esm.js",
+      "require": "./components/dist/index.cjs"
     },
     "./extras": {
-      "import": {
-        "types": "./extras/dist/index.cjs.d.ts",
-        "default": "./extras/dist/index.esm.js"
-      },
-      "require": {
-        "types": "./extras/dist/index.cjs.d.ts",
-        "default": "./extras/dist/index.cjs"
-      }
+      "types": "./extras/dist/index.cjs.d.ts",
+      "import": "./extras/dist/index.esm.js",
+      "require": "./extras/dist/index.cjs"
     },
     "./themes/apac": {
-      "import": {
-        "types": "./themes/apac/dist/index.cjs.d.ts",
-        "default": "./themes/apac/dist/index.esm.js"
-      },
-      "require": {
-        "types": "./themes/apac/dist/index.cjs.d.ts",
-        "default": "./themes/apac/dist/index.cjs"
-      }
+      "types": "./themes/apac/dist/index.cjs.d.ts",
+      "import": "./themes/apac/dist/index.esm.js",
+      "require": "./themes/apac/dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",

--- a/fixtures/multi-entry-library/package.json
+++ b/fixtures/multi-entry-library/package.json
@@ -63,7 +63,7 @@
   },
   "dependencies": {
     "@crackle/router": "workspace:*",
-    "braid-design-system": "0.0.0-crackel2-20220901020334",
+    "braid-design-system": "0.0.0-crackel2-20220919072731",
     "react": "17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/fixtures/single-entry-library/.gitignore
+++ b/fixtures/single-entry-library/.gitignore
@@ -1,0 +1,3 @@
+# managed by crackle
+/dist
+# end managed by crackle

--- a/fixtures/single-entry-library/package.json
+++ b/fixtures/single-entry-library/package.json
@@ -9,7 +9,7 @@
     ".": {
       "import": {
         "types": "./dist/index.cjs.d.ts",
-        "default": "./dist/index.mjs"
+        "default": "./dist/index.esm.js"
       },
       "require": {
         "types": "./dist/index.cjs.d.ts",
@@ -17,8 +17,8 @@
       }
     }
   },
-  "main": "dist/index.cjs",
-  "module": "dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.esm.js",
   "files": [
     "/dist"
   ],

--- a/fixtures/single-entry-library/package.json
+++ b/fixtures/single-entry-library/package.json
@@ -7,14 +7,9 @@
   "exports": {
     "./package.json": "./package.json",
     ".": {
-      "import": {
-        "types": "./dist/index.cjs.d.ts",
-        "default": "./dist/index.esm.js"
-      },
-      "require": {
-        "types": "./dist/index.cjs.d.ts",
-        "default": "./dist/index.cjs"
-      }
+      "types": "./dist/index.cjs.d.ts",
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",

--- a/fixtures/single-entry-library/package.json
+++ b/fixtures/single-entry-library/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@crackle-fixtures/multi-entry-library": "workspace:*",
     "@vanilla-extract/css": "^1.7.3",
-    "braid-design-system": "0.0.0-crackel2-20220901020334",
+    "braid-design-system": "0.0.0-crackel2-20220919072731",
     "react": "17.0.2",
     "react-dom": "^17.0.2"
   },

--- a/package.json
+++ b/package.json
@@ -5,9 +5,9 @@
   "scripts": {
     "fix": "preconstruct fix",
     "dev": "preconstruct dev",
-    "dev-fixtures": "pnpm -r dev",
     "build": "preconstruct build",
     "watch": "preconstruct watch",
+    "fixtures": "pnpm --recursive --filter='@crackle-fixtures/*'",
     "lint": "tsc --noEmit && eslint . && prettier --check .",
     "format": "eslint --fix . && prettier --write .",
     "test": "pnpm test:vitest --run && pnpm test:playwright",

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -94,6 +94,10 @@ yargs(process.argv.slice(2))
         description: 'Run `crackle fix` if necessary',
         type: 'boolean',
       },
+      clean: {
+        description: 'Clean output directory',
+        type: 'boolean',
+      },
     },
     handler: async (overrides) => {
       const config = await resolveConfig();

--- a/packages/core/entries/render/build.tsx
+++ b/packages/core/entries/render/build.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { renderToString } from 'react-dom/server';
 import type { Manifest } from 'vite';
 
-import { logger } from '../../src/logger';
+import { logger } from '../../logger';
 import type { RenderAllPagesFn } from '../types';
 
 import { createRouteMap, nodePageModules, Page } from './shared';

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -6,6 +6,7 @@ import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import builtinModules from 'builtin-modules';
 import chalk from 'chalk';
 import { readJson } from 'fs-extra';
+import type { RollupOutput } from 'rollup';
 import type { InlineConfig as ViteConfig, Manifest } from 'vite';
 import { build as viteBuild } from 'vite';
 
@@ -86,7 +87,9 @@ export const build = async (inlineConfig?: PartialConfig) => {
   try {
     logger.info(`🛠  Building ${chalk.bold('renderer')}...`);
 
-    await viteBuild({
+    const {
+      output: [rendererOutput],
+    } = (await viteBuild({
       ...commonBuildConfig,
       mode: 'development',
       base: config.publicPath,
@@ -106,8 +109,8 @@ export const build = async (inlineConfig?: PartialConfig) => {
         ...commonBuildConfig.ssr,
         format: 'cjs',
       },
-      // end remove
-    });
+      // TODO: end remove
+    })) as RollupOutput;
 
     logger.info(`✅ Successfully built ${chalk.bold('renderer')}!`);
 
@@ -120,7 +123,9 @@ export const build = async (inlineConfig?: PartialConfig) => {
       getIdentOption: () => 'short',
     });
 
-    const { renderAllPages } = (await import(`${rendererOutDir}/build.js`)) as {
+    const { renderAllPages } = (await import(
+      `${rendererOutDir}/${rendererOutput.fileName}`
+    )) as {
       renderAllPages: RenderAllPagesFn;
     };
     const manifest = (await readJson(

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -82,7 +82,8 @@ export const build = async (inlineConfig?: PartialConfig) => {
     return;
   }
 
-  const rendererOutDir = config.resolveFromRoot('dist-render');
+  const rendererDir = config.resolveFromRoot('dist-render');
+  const outDir = config.resolveFromRoot('dist');
 
   try {
     logger.info(`🛠  Building ${chalk.bold('renderer')}...`);
@@ -99,7 +100,7 @@ export const build = async (inlineConfig?: PartialConfig) => {
         rollupOptions: {
           input: require.resolve('../../entries/render/build.tsx'),
         },
-        outDir: rendererOutDir,
+        outDir: rendererDir,
       },
       // TODO: remove when this PR lands https://github.com/vitejs/vite/pull/9989
       legacy: {
@@ -124,26 +125,24 @@ export const build = async (inlineConfig?: PartialConfig) => {
     });
 
     const { renderAllPages } = (await import(
-      `${rendererOutDir}/${rendererOutput.fileName}`
+      `${rendererDir}/${rendererOutput.fileName}`
     )) as {
       renderAllPages: RenderAllPagesFn;
     };
-    const manifest = (await readJson(
-      config.resolveFromRoot('dist/manifest.json'),
-    )) as Manifest;
+    const manifest = (await readJson(`${outDir}/manifest.json`)) as Manifest;
     const pages = await renderAllPages(manifest, config.publicPath);
 
     await promiseMap(pages, async ({ route, html }) => {
-      const dir = config.resolveFromRoot(path.join('dist', route));
-      await fs.mkdir(dir, { recursive: true });
-      return fs.writeFile(`${dir}/index.html`, html);
+      const routeDir = path.join(outDir, route);
+      await fs.mkdir(routeDir, { recursive: true });
+      return fs.writeFile(`${routeDir}/index.html`, html);
     });
 
     logger.info('✅ Rendered all pages');
   } catch (error: any) {
     logger.errorWithExitCode(renderBuildError(`Render pages failed`, error));
   } finally {
-    await fs.rm(rendererOutDir, {
+    await fs.rm(rendererDir, {
       recursive: true,
       force: true,
     });

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,6 +1,8 @@
 import fs from 'fs';
 import path from 'path';
 
+import type { CompilerOptions } from 'typescript';
+
 export interface Config {
   /**
    * Automatically run `fix` if necessary.
@@ -37,6 +39,12 @@ export interface Config {
    * @default 'src/App.tsx'
    */
   appShell: `${string}.tsx`;
+
+  /**
+   * Override TypeScript `compilerOptions` for when generating `.d.ts` files
+   * @default '{ incremental: false, noEmitOnError: false }'
+   */
+  dtsOptions: CompilerOptions;
 }
 
 export interface EnhancedConfig extends Config {
@@ -52,6 +60,10 @@ export const defaultConfig: Config = {
   root: process.cwd(),
   pageRoots: ['src'],
   appShell: 'src/App.tsx',
+  dtsOptions: {
+    incremental: false,
+    noEmitOnError: false,
+  },
 };
 
 const determineAppShell = (
@@ -76,6 +88,10 @@ export const getConfig = (inlineConfig?: PartialConfig): EnhancedConfig => {
   const config = {
     ...defaultConfig,
     ...inlineConfig,
+    dtsOptions: {
+      ...defaultConfig.dtsOptions,
+      ...inlineConfig?.dtsOptions,
+    },
   };
 
   const resolveFromRoot = (filePath: string) =>

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -3,6 +3,12 @@ import path from 'path';
 
 export interface Config {
   /**
+   * Automatically clean output directory when running `package`.
+   * @default true
+   */
+  clean: boolean;
+
+  /**
    * Automatically run `fix` if necessary.
    * @default false
    */
@@ -52,6 +58,7 @@ export interface EnhancedConfig extends Config {
 export type PartialConfig = Partial<Config>;
 
 export const defaultConfig: Config = {
+  clean: true,
   fix: false,
   port: 5000,
   publicPath: '/',

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,8 +1,6 @@
 import fs from 'fs';
 import path from 'path';
 
-import type { CompilerOptions } from 'typescript';
-
 export interface Config {
   /**
    * Automatically run `fix` if necessary.
@@ -44,7 +42,7 @@ export interface Config {
    * Override TypeScript `compilerOptions` for when generating `.d.ts` files
    * @default '{ incremental: false, noEmitOnError: false }'
    */
-  dtsOptions: CompilerOptions;
+  dtsOptions: Record<string, unknown>;
 }
 
 export interface EnhancedConfig extends Config {

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -83,7 +83,7 @@ const build = async (config: EnhancedConfig, packageName: string) => {
           throw new Error('Unable to name entry file');
         }
 
-        return `${entry.entryName}/index.${extension}`;
+        return `${entry.entryName}/dist/index.${extension}`;
       },
       chunkFileNames(chunkInfo) {
         const chunkPath = `dist/${chunkInfo.name}`;

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -83,7 +83,7 @@ const build = async (config: EnhancedConfig, packageName: string) => {
           throw new Error('Unable to name entry file');
         }
 
-        return `${entry.entryName}/dist/index.${extension}`;
+        return `${entry.entryName}/index.${extension}`;
       },
       chunkFileNames(chunkInfo) {
         const chunkPath = `dist/${chunkInfo.name}`;

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -70,7 +70,7 @@ const build = async (config: EnhancedConfig, packageName: string) => {
 
     const extension = extensionForFormat(format);
 
-    await bundle(config.root, entries, {
+    await bundle(config, entries, {
       dir: config.root,
       exports: 'auto',
       format: toRollupFormat(format),

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -60,7 +60,9 @@ const build = async (config: EnhancedConfig, packageName: string) => {
 
   logger.info(`🛠  Building ${chalk.bold.green(packageName)}...`);
 
-  await promiseMap(entries, (entry) => emptyDir(entry.outputDir));
+  if (config.clean) {
+    await promiseMap(entries, (entry) => emptyDir(entry.outputDir));
+  }
 
   const withLogging = async (
     bundle: typeof createBundle | typeof createDtsBundle,

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -85,13 +85,6 @@ const build = async (config: EnhancedConfig, packageName: string) => {
 
         return `${entry.entryName}/index.${extension}`;
       },
-      chunkFileNames(chunkInfo) {
-        const chunkPath = `dist/${chunkInfo.name}`;
-
-        return chunkPath.endsWith(extension)
-          ? chunkPath
-          : `${chunkPath}.chunk.${extension}`;
-      },
     });
 
     logger.info(`⚙️  Finished creating ${chalk.bold(format)} bundle`);

--- a/packages/core/src/package/bundle.ts
+++ b/packages/core/src/package/bundle.ts
@@ -5,6 +5,7 @@ import { rollup } from 'rollup';
 import type { OutputOptions } from 'rollup';
 import esbuild from 'rollup-plugin-esbuild';
 
+import type { EnhancedConfig } from '../config';
 import type { Format } from '../package';
 import { extensionForFormat } from '../package';
 import { externals } from '../plugins/rollup';
@@ -12,7 +13,7 @@ import { addVanillaDebugIds } from '../plugins/vite';
 import type { PackageEntryPoint } from '../types';
 
 export const createBundle = async (
-  packageRoot: string,
+  config: EnhancedConfig,
   entries: PackageEntryPoint[],
   outputOptions: OutputOptions,
 ) => {
@@ -22,7 +23,7 @@ export const createBundle = async (
   const bundle = await rollup({
     input: entries.map(({ entryPath }) => entryPath),
     plugins: [
-      externals(packageRoot),
+      externals(config.root),
       nodeResolve(),
       commonjs(),
       esbuild({

--- a/packages/core/src/package/bundle.ts
+++ b/packages/core/src/package/bundle.ts
@@ -6,11 +6,10 @@ import type { OutputOptions } from 'rollup';
 import esbuild from 'rollup-plugin-esbuild';
 
 import type { EnhancedConfig } from '../config';
-import type { Format } from '../package';
-import { extensionForFormat } from '../package';
 import { externals } from '../plugins/rollup';
 import { addVanillaDebugIds } from '../plugins/vite';
-import type { PackageEntryPoint } from '../types';
+import type { Format, PackageEntryPoint } from '../types';
+import { extensionForFormat } from '../utils/files';
 
 export const createBundle = async (
   config: EnhancedConfig,

--- a/packages/core/src/package/bundle.ts
+++ b/packages/core/src/package/bundle.ts
@@ -69,6 +69,13 @@ export const createBundle = async (
           : localPath.replace(/\.(ts|tsx|js|mjs|cjs|jsx)$/, `.${extension}`);
       }
     },
+    chunkFileNames(chunkInfo) {
+      const chunkPath = `dist/${chunkInfo.name}`;
+
+      return chunkPath.endsWith(extension)
+        ? chunkPath
+        : `${chunkPath}.chunk.${extension}`;
+    },
   });
 
   await bundle.close();

--- a/packages/core/src/package/dts.ts
+++ b/packages/core/src/package/dts.ts
@@ -5,29 +5,33 @@ import dts from 'rollup-plugin-dts';
 import type { EnhancedConfig } from '../config';
 import { externals } from '../plugins/rollup';
 import type { PackageEntryPoint } from '../types';
+import { promiseMap } from '../utils/promise-map';
 
 export const createDtsBundle = async (
   config: EnhancedConfig,
   entries: PackageEntryPoint[],
   outputOptions: OutputOptions,
 ) => {
-  const bundle = await rollup({
-    input: entries.map(({ entryPath }) => entryPath),
-    plugins: [
-      externals(config.root),
-      dts({
-        respectExternal: true,
-        compilerOptions: config.dtsOptions as any,
-      }),
-    ],
-  });
+  // We're bundling each entry separately to avoid chunking
+  await promiseMap(entries, async (entry) => {
+    const bundle = await rollup({
+      input: entry.entryPath,
+      plugins: [
+        externals(config.root),
+        dts({
+          respectExternal: true,
+          compilerOptions: config.dtsOptions as any,
+        }),
+      ],
+    });
 
-  await bundle.write({
-    ...outputOptions,
-    chunkFileNames: 'dist/[name]-[hash].d.ts',
-    exports: 'named',
-    format: 'esm',
-  });
+    await bundle.write({
+      ...outputOptions,
+      exports: 'named',
+      format: 'esm',
+      minifyInternalExports: false,
+    });
 
-  await bundle.close();
+    await bundle.close();
+  });
 };

--- a/packages/core/src/package/dts.ts
+++ b/packages/core/src/package/dts.ts
@@ -17,7 +17,7 @@ export const createDtsBundle = async (
       externals(config.root),
       dts({
         respectExternal: true,
-        compilerOptions: config.dtsOptions,
+        compilerOptions: config.dtsOptions as any,
       }),
     ],
   });

--- a/packages/core/src/package/dts.ts
+++ b/packages/core/src/package/dts.ts
@@ -24,6 +24,7 @@ export const createDtsBundle = async (
 
   await bundle.write({
     ...outputOptions,
+    chunkFileNames: 'dist/[name]-[hash].d.ts',
     exports: 'named',
     format: 'esm',
   });

--- a/packages/core/src/package/dts.ts
+++ b/packages/core/src/package/dts.ts
@@ -2,20 +2,22 @@ import type { OutputOptions } from 'rollup';
 import { rollup } from 'rollup';
 import dts from 'rollup-plugin-dts';
 
+import type { EnhancedConfig } from '../config';
 import { externals } from '../plugins/rollup';
 import type { PackageEntryPoint } from '../types';
 
 export const createDtsBundle = async (
-  packageRoot: string,
+  config: EnhancedConfig,
   entries: PackageEntryPoint[],
   outputOptions: OutputOptions,
 ) => {
   const bundle = await rollup({
     input: entries.map(({ entryPath }) => entryPath),
     plugins: [
-      externals(packageRoot),
+      externals(config.root),
       dts({
         respectExternal: true,
+        compilerOptions: config.dtsOptions,
       }),
     ],
   });

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -3,6 +3,8 @@ import type { InlineConfig } from 'vite';
 
 export type { PackageJson } from 'type-fest';
 
+export type Format = 'esm' | 'cjs' | 'dts';
+
 export type GetArrayType<T> = T extends Array<infer U> ? U : never;
 
 export type ManualChunksFn = NonNullable<
@@ -27,20 +29,10 @@ export interface CrackleServer {
   close: () => Promise<void>;
 }
 
-interface DefaultPackageEntryPoint {
-  isDefaultEntry: true;
+export type PackageEntryPoint = {
+  isDefaultEntry: boolean;
+  entryName: string;
   entryPath: string;
   outputDir: string;
-  entryName: string;
-}
-
-interface OtherPackageEntryPoint {
-  isDefaultEntry: false;
-  entryPath: string;
-  outputDir: string;
-  entryName: string;
-}
-
-export type PackageEntryPoint =
-  | DefaultPackageEntryPoint
-  | OtherPackageEntryPoint;
+  getOutputPath: (format: Format) => string;
+};

--- a/packages/core/src/utils/__snapshots__/setup-package-json.test.ts.snap
+++ b/packages/core/src/utils/__snapshots__/setup-package-json.test.ts.snap
@@ -5,12 +5,12 @@ exports[`diffPackageJson > Empty package.json > diffs 1`] = `
   {
     "from": undefined,
     "key": "main",
-    "to": "dist/index.cjs",
+    "to": "./dist/index.cjs",
   },
   {
     "from": undefined,
     "key": "module",
-    "to": "dist/index.mjs",
+    "to": "./dist/index.esm.js",
   },
   {
     "additions": [
@@ -31,7 +31,7 @@ exports[`diffPackageJson > Empty package.json > expectedPackageJson 1`] = `
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/index.mjs",
+        "default": "./dist/index.esm.js",
         "types": "./dist/index.cjs.d.ts",
       },
       "require": {
@@ -41,23 +41,23 @@ exports[`diffPackageJson > Empty package.json > expectedPackageJson 1`] = `
     },
     "./css": {
       "import": {
-        "default": "./css/index.mjs",
-        "types": "./css/index.cjs.d.ts",
+        "default": "./css/dist/index.esm.js",
+        "types": "./css/dist/index.cjs.d.ts",
       },
       "require": {
-        "default": "./css/index.cjs",
-        "types": "./css/index.cjs.d.ts",
+        "default": "./css/dist/index.cjs",
+        "types": "./css/dist/index.cjs.d.ts",
       },
     },
     "./package.json": "./package.json",
     "./themes/apac": {
       "import": {
-        "default": "./themes/apac/index.mjs",
-        "types": "./themes/apac/index.cjs.d.ts",
+        "default": "./themes/apac/dist/index.esm.js",
+        "types": "./themes/apac/dist/index.cjs.d.ts",
       },
       "require": {
-        "default": "./themes/apac/index.cjs",
-        "types": "./themes/apac/index.cjs.d.ts",
+        "default": "./themes/apac/dist/index.cjs",
+        "types": "./themes/apac/dist/index.cjs.d.ts",
       },
     },
   },
@@ -66,26 +66,23 @@ exports[`diffPackageJson > Empty package.json > expectedPackageJson 1`] = `
     "/dist",
     "/themes/apac",
   ],
-  "main": "dist/index.cjs",
-  "module": "dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.esm.js",
 }
 `;
 
 exports[`diffPackageJson > Incorrect package.json > diffs 1`] = `
 [
   {
-    "from": "dist/index.esm",
+    "from": "dist/index.esm.invalid",
     "key": "module",
-    "to": "dist/index.mjs",
+    "to": "./dist/index.esm.js",
   },
   {
     "additions": [
       "/themes/apac",
     ],
     "key": "files",
-  },
-  {
-    "key": "exports",
   },
 ]
 `;
@@ -95,7 +92,7 @@ exports[`diffPackageJson > Incorrect package.json > expectedPackageJson 1`] = `
   "exports": {
     ".": {
       "import": {
-        "default": "./dist/index.mjs",
+        "default": "./dist/index.esm.js",
         "types": "./dist/index.cjs.d.ts",
       },
       "require": {
@@ -105,23 +102,23 @@ exports[`diffPackageJson > Incorrect package.json > expectedPackageJson 1`] = `
     },
     "./css": {
       "import": {
-        "default": "./css/index.mjs",
-        "types": "./css/index.cjs.d.ts",
+        "default": "./css/dist/index.esm.js",
+        "types": "./css/dist/index.cjs.d.ts",
       },
       "require": {
-        "default": "./css/index.cjs",
-        "types": "./css/index.cjs.d.ts",
+        "default": "./css/dist/index.cjs",
+        "types": "./css/dist/index.cjs.d.ts",
       },
     },
     "./package.json": "./package.json",
     "./themes/apac": {
       "import": {
-        "default": "./themes/apac/index.mjs",
-        "types": "./themes/apac/index.cjs.d.ts",
+        "default": "./themes/apac/dist/index.esm.js",
+        "types": "./themes/apac/dist/index.cjs.d.ts",
       },
       "require": {
-        "default": "./themes/apac/index.cjs",
-        "types": "./themes/apac/index.cjs.d.ts",
+        "default": "./themes/apac/dist/index.cjs",
+        "types": "./themes/apac/dist/index.cjs.d.ts",
       },
     },
   },
@@ -131,7 +128,7 @@ exports[`diffPackageJson > Incorrect package.json > expectedPackageJson 1`] = `
     "/dist",
     "/themes/apac",
   ],
-  "main": "dist/index.cjs",
-  "module": "dist/index.mjs",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.esm.js",
 }
 `;

--- a/packages/core/src/utils/__snapshots__/setup-package-json.test.ts.snap
+++ b/packages/core/src/utils/__snapshots__/setup-package-json.test.ts.snap
@@ -30,35 +30,20 @@ exports[`diffPackageJson > Empty package.json > expectedPackageJson 1`] = `
 {
   "exports": {
     ".": {
-      "import": {
-        "default": "./dist/index.esm.js",
-        "types": "./dist/index.cjs.d.ts",
-      },
-      "require": {
-        "default": "./dist/index.cjs",
-        "types": "./dist/index.cjs.d.ts",
-      },
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.cjs.d.ts",
     },
     "./css": {
-      "import": {
-        "default": "./css/dist/index.esm.js",
-        "types": "./css/dist/index.cjs.d.ts",
-      },
-      "require": {
-        "default": "./css/dist/index.cjs",
-        "types": "./css/dist/index.cjs.d.ts",
-      },
+      "import": "./css/dist/index.esm.js",
+      "require": "./css/dist/index.cjs",
+      "types": "./css/dist/index.cjs.d.ts",
     },
     "./package.json": "./package.json",
     "./themes/apac": {
-      "import": {
-        "default": "./themes/apac/dist/index.esm.js",
-        "types": "./themes/apac/dist/index.cjs.d.ts",
-      },
-      "require": {
-        "default": "./themes/apac/dist/index.cjs",
-        "types": "./themes/apac/dist/index.cjs.d.ts",
-      },
+      "import": "./themes/apac/dist/index.esm.js",
+      "require": "./themes/apac/dist/index.cjs",
+      "types": "./themes/apac/dist/index.cjs.d.ts",
     },
   },
   "files": [
@@ -84,6 +69,9 @@ exports[`diffPackageJson > Incorrect package.json > diffs 1`] = `
     ],
     "key": "files",
   },
+  {
+    "key": "exports",
+  },
 ]
 `;
 
@@ -91,35 +79,20 @@ exports[`diffPackageJson > Incorrect package.json > expectedPackageJson 1`] = `
 {
   "exports": {
     ".": {
-      "import": {
-        "default": "./dist/index.esm.js",
-        "types": "./dist/index.cjs.d.ts",
-      },
-      "require": {
-        "default": "./dist/index.cjs",
-        "types": "./dist/index.cjs.d.ts",
-      },
+      "import": "./dist/index.esm.js",
+      "require": "./dist/index.cjs",
+      "types": "./dist/index.cjs.d.ts",
     },
     "./css": {
-      "import": {
-        "default": "./css/dist/index.esm.js",
-        "types": "./css/dist/index.cjs.d.ts",
-      },
-      "require": {
-        "default": "./css/dist/index.cjs",
-        "types": "./css/dist/index.cjs.d.ts",
-      },
+      "import": "./css/dist/index.esm.js",
+      "require": "./css/dist/index.cjs",
+      "types": "./css/dist/index.cjs.d.ts",
     },
     "./package.json": "./package.json",
     "./themes/apac": {
-      "import": {
-        "default": "./themes/apac/dist/index.esm.js",
-        "types": "./themes/apac/dist/index.cjs.d.ts",
-      },
-      "require": {
-        "default": "./themes/apac/dist/index.cjs",
-        "types": "./themes/apac/dist/index.cjs.d.ts",
-      },
+      "import": "./themes/apac/dist/index.esm.js",
+      "require": "./themes/apac/dist/index.cjs",
+      "types": "./themes/apac/dist/index.cjs.d.ts",
     },
   },
   "files": [

--- a/packages/core/src/utils/create-entry-package-json.ts
+++ b/packages/core/src/utils/create-entry-package-json.ts
@@ -1,6 +1,6 @@
 import path from 'path';
 
-import type { PackageEntryPoint } from '../types';
+import type { Format, PackageEntryPoint } from '../types';
 
 import { writePackageJson } from './files';
 import { promiseMap } from './promise-map';
@@ -8,19 +8,17 @@ import { promiseMap } from './promise-map';
 export const createEntryPackageJsons = async (
   entryPoints: PackageEntryPoint[],
 ) => {
+  const relativeOutputPath = (entryPoint: PackageEntryPoint, format: Format) =>
+    path.relative(entryPoint.outputDir, entryPoint.getOutputPath(format));
+
   await promiseMap(entryPoints, async (entryPoint) => {
     if (!entryPoint.isDefaultEntry) {
       await writePackageJson({
         dir: entryPoint.outputDir,
         contents: {
-          main: path.relative(
-            entryPoint.outputDir,
-            entryPoint.getOutputPath('cjs'),
-          ),
-          module: path.relative(
-            entryPoint.outputDir,
-            entryPoint.getOutputPath('esm'),
-          ),
+          main: relativeOutputPath(entryPoint, 'cjs'),
+          module: relativeOutputPath(entryPoint, 'esm'),
+          types: relativeOutputPath(entryPoint, 'dts'),
         },
       });
     }

--- a/packages/core/src/utils/create-entry-package-json.ts
+++ b/packages/core/src/utils/create-entry-package-json.ts
@@ -1,4 +1,6 @@
-import type { PackageEntryPoint, PackageJson } from '../types';
+import path from 'path';
+
+import type { PackageEntryPoint } from '../types';
 
 import { writePackageJson } from './files';
 import { promiseMap } from './promise-map';
@@ -6,17 +8,20 @@ import { promiseMap } from './promise-map';
 export const createEntryPackageJsons = async (
   entryPoints: PackageEntryPoint[],
 ) => {
-  // TODO: don't hardcode
-  const packageContents: PackageJson = {
-    main: 'index.cjs',
-    module: 'index.mjs',
-  };
-
   await promiseMap(entryPoints, async (entryPoint) => {
     if (!entryPoint.isDefaultEntry) {
       await writePackageJson({
         dir: entryPoint.outputDir,
-        contents: packageContents,
+        contents: {
+          main: path.relative(
+            entryPoint.outputDir,
+            entryPoint.getOutputPath('cjs'),
+          ),
+          module: path.relative(
+            entryPoint.outputDir,
+            entryPoint.getOutputPath('esm'),
+          ),
+        },
       });
     }
   });

--- a/packages/core/src/utils/files.ts
+++ b/packages/core/src/utils/files.ts
@@ -2,9 +2,10 @@ import { existsSync } from 'fs';
 import fs from 'fs/promises';
 import path from 'path';
 
+import type { ModuleFormat } from 'rollup';
 import sortPackageJson from 'sort-package-json';
 
-import type { PackageJson } from '../types';
+import type { Format, PackageJson } from '../types';
 
 interface WriteFileOpts {
   dir: string;
@@ -68,3 +69,9 @@ export const emptyDir = async (dir: string, skip = ['.git']): Promise<void> => {
     await fs.rm(path.resolve(dir, file), { recursive: true, force: true });
   }
 };
+
+export const extensionForFormat = (format: Format) =>
+  (({ esm: 'esm.js', cjs: 'cjs', dts: 'cjs.d.ts' } as const)[format]);
+
+export const toRollupFormat = (format: Format): ModuleFormat =>
+  (({ esm: 'esm', cjs: 'cjs', dts: 'esm' } as const)[format]);

--- a/packages/core/src/utils/files.ts
+++ b/packages/core/src/utils/files.ts
@@ -22,6 +22,10 @@ export const writeIfRequired = async ({
   fileName,
   contents,
 }: WriteFileOpts) => {
+  if (!existsSync(dir)) {
+    await fs.mkdir(dir, { recursive: true });
+  }
+
   const filePath = path.join(dir, fileName);
 
   let write = false;
@@ -53,12 +57,12 @@ export const writePackageJson = async <T extends PackageJson>({
 
 export const emptyDir = async (dir: string, skip = ['.git']): Promise<void> => {
   if (!existsSync(dir)) {
-    fs.mkdir(dir, { recursive: true });
+    await fs.mkdir(dir, { recursive: true });
     return;
   }
 
   for (const file of await fs.readdir(dir)) {
-    if (skip?.includes(file)) {
+    if (skip.includes(file)) {
       continue;
     }
     await fs.rm(path.resolve(dir, file), { recursive: true, force: true });

--- a/packages/core/src/utils/get-packages.test.ts
+++ b/packages/core/src/utils/get-packages.test.ts
@@ -28,24 +28,28 @@ test('getPackageEntryPoints', async () => {
       {
         "entryName": "dist",
         "entryPath": "/fixtures/multi-entry/src/index.ts",
+        "getOutputPath": [Function],
         "isDefaultEntry": true,
         "outputDir": "/fixtures/multi-entry/dist",
       },
       {
         "entryName": "components",
         "entryPath": "/fixtures/multi-entry/src/entries/components.ts",
+        "getOutputPath": [Function],
         "isDefaultEntry": false,
         "outputDir": "/fixtures/multi-entry/components",
       },
       {
         "entryName": "extras",
         "entryPath": "/fixtures/multi-entry/src/entries/extras.ts",
+        "getOutputPath": [Function],
         "isDefaultEntry": false,
         "outputDir": "/fixtures/multi-entry/extras",
       },
       {
         "entryName": "themes/apac",
         "entryPath": "/fixtures/multi-entry/src/entries/themes/apac.ts",
+        "getOutputPath": [Function],
         "isDefaultEntry": false,
         "outputDir": "/fixtures/multi-entry/themes/apac",
       },

--- a/packages/core/src/utils/get-packages.ts
+++ b/packages/core/src/utils/get-packages.ts
@@ -4,7 +4,9 @@ import path from 'path';
 import glob from 'fast-glob';
 
 import type { EnhancedConfig } from '../config';
-import type { PackageEntryPoint } from '../types';
+import type { Format, PackageEntryPoint } from '../types';
+
+import { extensionForFormat } from './files';
 
 export interface Package {
   name: string;
@@ -44,15 +46,15 @@ export const getPackages = async (
   return packages;
 };
 
-const defaultEntry = 'src/index.ts';
-const otherEntries = 'src/entries';
-
 interface GetPackageEntryPointsOpts {
   packageRoot: string;
 }
 export const getPackageEntryPoints = async ({
   packageRoot,
 }: GetPackageEntryPointsOpts): Promise<PackageEntryPoint[]> => {
+  const defaultEntry = 'src/index.ts';
+  const otherEntries = 'src/entries';
+
   const entryPaths = await glob([defaultEntry, `${otherEntries}/**/*.ts`], {
     cwd: packageRoot,
     fs,
@@ -71,6 +73,12 @@ export const getPackageEntryPoints = async ({
       entryPath: path.join(packageRoot, entryPath),
       isDefaultEntry,
       outputDir,
+      getOutputPath: (format: Format) =>
+        path.join(
+          entryName,
+          isDefaultEntry ? '' : 'dist',
+          `index.${extensionForFormat(format)}`,
+        ),
     };
   });
 };

--- a/packages/core/src/utils/setup-package-json.test.ts
+++ b/packages/core/src/utils/setup-package-json.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'vitest';
 
+import type { Format } from '../types';
+
+import { extensionForFormat } from './files';
 import { diffPackageJson } from './setup-package-json';
 
 const entries = [
@@ -8,18 +11,24 @@ const entries = [
     entryName: 'dist',
     entryPath: '/project/src/index.ts',
     outputDir: '/project/dist',
+    getOutputPath: (format: Format) =>
+      `dist/index.${extensionForFormat(format)}`,
   },
   {
     isDefaultEntry: false,
     entryName: 'css',
     entryPath: '/project/src/entries/css.ts',
     outputDir: '/project/css',
+    getOutputPath: (format: Format) =>
+      `css/dist/index.${extensionForFormat(format)}`,
   },
   {
     isDefaultEntry: false,
     entryName: 'themes/apac',
     entryPath: '/project/src/entries/themes/apac.ts',
     outputDir: '/project/themes/apac',
+    getOutputPath: (format: Format) =>
+      `themes/apac/dist/index.${extensionForFormat(format)}`,
   },
 ];
 
@@ -37,7 +46,7 @@ describe('diffPackageJson', () => {
         exports: {
           '.': {
             import: {
-              default: './dist/index.esm',
+              default: './dist/index.esm.js',
               types: './dist/index.cjs.d.ts',
             },
             require: {
@@ -47,29 +56,29 @@ describe('diffPackageJson', () => {
           },
           './css': {
             import: {
-              default: './css/index.esm',
-              types: './css/index.cjs.d.ts',
+              default: './css/dist/index.esm.js',
+              types: './css/dist/index.cjs.d.ts',
             },
             require: {
-              default: './css/index.cjs',
-              types: './css/index.cjs.d.ts',
+              default: './css/dist/index.cjs',
+              types: './css/dist/index.cjs.d.ts',
             },
           },
           './package.json': './package.json',
           './themes/apac': {
             import: {
-              default: './themes/apac/index.esm',
-              types: './themes/apac/index.cjs.d.ts',
+              default: './themes/apac/dist/index.esm.js',
+              types: './themes/apac/dist/index.cjs.d.ts',
             },
             require: {
-              default: './themes/apac/index.cjs',
-              types: './themes/apac/index.cjs.d.ts',
+              default: './themes/apac/dist/index.cjs',
+              types: './themes/apac/dist/index.cjs.d.ts',
             },
           },
         },
         files: ['/css', '/dist', '/apac'],
-        main: 'dist/index.cjs',
-        module: 'dist/index.esm',
+        main: './dist/index.cjs',
+        module: 'dist/index.esm.invalid',
       },
       entries,
     );
@@ -84,7 +93,7 @@ describe('diffPackageJson', () => {
         exports: {
           '.': {
             import: {
-              default: './dist/index.mjs',
+              default: './dist/index.esm.js',
               types: './dist/index.cjs.d.ts',
             },
             require: {
@@ -94,29 +103,29 @@ describe('diffPackageJson', () => {
           },
           './css': {
             import: {
-              default: './css/index.mjs',
-              types: './css/index.cjs.d.ts',
+              default: './css/dist/index.esm.js',
+              types: './css/dist/index.cjs.d.ts',
             },
             require: {
-              default: './css/index.cjs',
-              types: './css/index.cjs.d.ts',
+              default: './css/dist/index.cjs',
+              types: './css/dist/index.cjs.d.ts',
             },
           },
           './package.json': './package.json',
           './themes/apac': {
             import: {
-              default: './themes/apac/index.mjs',
-              types: './themes/apac/index.cjs.d.ts',
+              default: './themes/apac/dist/index.esm.js',
+              types: './themes/apac/dist/index.cjs.d.ts',
             },
             require: {
-              default: './themes/apac/index.cjs',
-              types: './themes/apac/index.cjs.d.ts',
+              default: './themes/apac/dist/index.cjs',
+              types: './themes/apac/dist/index.cjs.d.ts',
             },
           },
         },
         files: ['/css', '/dist', '/themes/apac'],
-        main: 'dist/index.cjs',
-        module: 'dist/index.mjs',
+        main: './dist/index.cjs',
+        module: './dist/index.esm.js',
       },
       entries,
     );

--- a/packages/core/src/utils/setup-package-json.test.ts
+++ b/packages/core/src/utils/setup-package-json.test.ts
@@ -55,25 +55,15 @@ describe('diffPackageJson', () => {
             },
           },
           './css': {
-            import: {
-              default: './css/dist/index.esm.js',
-              types: './css/dist/index.cjs.d.ts',
-            },
-            require: {
-              default: './css/dist/index.cjs',
-              types: './css/dist/index.cjs.d.ts',
-            },
+            types: './css/dist/index.cjs.d.ts',
+            import: './css/dist/index.esm.js',
+            require: './css/dist/index.cjs',
           },
           './package.json': './package.json',
           './themes/apac': {
-            import: {
-              default: './themes/apac/dist/index.esm.js',
-              types: './themes/apac/dist/index.cjs.d.ts',
-            },
-            require: {
-              default: './themes/apac/dist/index.cjs',
-              types: './themes/apac/dist/index.cjs.d.ts',
-            },
+            types: './themes/apac/dist/index.cjs.d.ts',
+            import: './themes/apac/dist/index.esm.js',
+            require: './themes/apac/dist/index.cjs',
           },
         },
         files: ['/css', '/dist', '/apac'],
@@ -92,35 +82,20 @@ describe('diffPackageJson', () => {
       {
         exports: {
           '.': {
-            import: {
-              default: './dist/index.esm.js',
-              types: './dist/index.cjs.d.ts',
-            },
-            require: {
-              default: './dist/index.cjs',
-              types: './dist/index.cjs.d.ts',
-            },
+            types: './dist/index.cjs.d.ts',
+            import: './dist/index.esm.js',
+            require: './dist/index.cjs',
           },
           './css': {
-            import: {
-              default: './css/dist/index.esm.js',
-              types: './css/dist/index.cjs.d.ts',
-            },
-            require: {
-              default: './css/dist/index.cjs',
-              types: './css/dist/index.cjs.d.ts',
-            },
+            types: './css/dist/index.cjs.d.ts',
+            import: './css/dist/index.esm.js',
+            require: './css/dist/index.cjs',
           },
           './package.json': './package.json',
           './themes/apac': {
-            import: {
-              default: './themes/apac/dist/index.esm.js',
-              types: './themes/apac/dist/index.cjs.d.ts',
-            },
-            require: {
-              default: './themes/apac/dist/index.cjs',
-              types: './themes/apac/dist/index.cjs.d.ts',
-            },
+            types: './themes/apac/dist/index.cjs.d.ts',
+            import: './themes/apac/dist/index.esm.js',
+            require: './themes/apac/dist/index.cjs',
           },
         },
         files: ['/css', '/dist', '/themes/apac'],

--- a/packages/core/src/utils/setup-package-json.ts
+++ b/packages/core/src/utils/setup-package-json.ts
@@ -15,13 +15,10 @@ export type Difference =
   | ExportsDifference;
 
 type ExportString = `./${string}`;
-type ExportWithTypes = {
-  types: ExportString;
-  default: ExportString;
-};
 type ExportObject = {
-  import: ExportWithTypes;
-  require: ExportWithTypes;
+  types: ExportString;
+  import: ExportString;
+  require: ExportString;
 };
 
 const getExportsForPackage = (entries: PackageEntryPoint[]) => {
@@ -30,10 +27,10 @@ const getExportsForPackage = (entries: PackageEntryPoint[]) => {
   };
 
   for (const entryPoint of entries) {
-    const types = `./${entryPoint.getOutputPath('dts')}` as const;
     exports[entryPoint.isDefaultEntry ? '.' : `./${entryPoint.entryName}`] = {
-      import: { types, default: `./${entryPoint.getOutputPath('esm')}` },
-      require: { types, default: `./${entryPoint.getOutputPath('cjs')}` },
+      types: `./${entryPoint.getOutputPath('dts')}`,
+      import: `./${entryPoint.getOutputPath('esm')}`,
+      require: `./${entryPoint.getOutputPath('cjs')}`,
     };
   }
 

--- a/packages/core/src/utils/setup-package-json.ts
+++ b/packages/core/src/utils/setup-package-json.ts
@@ -15,12 +15,10 @@ export type Difference =
   | ExportsDifference;
 
 type ExportString = `./${string}`;
-
 type ExportWithTypes = {
   types: ExportString;
   default: ExportString;
 };
-
 type ExportObject = {
   import: ExportWithTypes;
   require: ExportWithTypes;
@@ -32,19 +30,10 @@ const getExportsForPackage = (entries: PackageEntryPoint[]) => {
   };
 
   for (const entryPoint of entries) {
-    if (entryPoint.isDefaultEntry) {
-      const types = './dist/index.cjs.d.ts';
-      exports['.'] = {
-        import: { types, default: './dist/index.mjs' },
-        require: { types, default: './dist/index.cjs' },
-      };
-      continue;
-    }
-
-    const types = `./${entryPoint.entryName}/index.cjs.d.ts` as const;
-    exports[`./${entryPoint.entryName}`] = {
-      import: { types, default: `./${entryPoint.entryName}/index.mjs` },
-      require: { types, default: `./${entryPoint.entryName}/index.cjs` },
+    const types = `./${entryPoint.getOutputPath('dts')}` as const;
+    exports[entryPoint.isDefaultEntry ? '.' : `./${entryPoint.entryName}`] = {
+      import: { types, default: `./${entryPoint.getOutputPath('esm')}` },
+      require: { types, default: `./${entryPoint.getOutputPath('cjs')}` },
     };
   }
 
@@ -62,8 +51,8 @@ export const diffPackageJson = (
 
   for (const entryPoint of entries) {
     if (entryPoint.isDefaultEntry) {
-      main = 'dist/index.cjs';
-      module = 'dist/index.mjs';
+      main = `./${entryPoint.getOutputPath('cjs')}`;
+      module = `./${entryPoint.getOutputPath('esm')}`;
     }
 
     files.add(`/${entryPoint.entryName}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,13 +45,13 @@ importers:
       '@types/react': ^17
       '@types/react-dom': ^17
       '@vanilla-extract/css': ^1.7.3
-      braid-design-system: 0.0.0-crackel2-20220901020334
+      braid-design-system: 0.0.0-crackel2-20220919072731
       react: 17.0.2
       react-dom: ^17.0.2
     dependencies:
       '@crackle/router': link:../../packages/router
       '@vanilla-extract/css': 1.9.0
-      braid-design-system: 0.0.0-crackel2-20220901020334_j6sw2p2tdbh6crpcmkxtmmhma4
+      braid-design-system: 0.0.0-crackel2-20220919072731_j6sw2p2tdbh6crpcmkxtmmhma4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -68,13 +68,13 @@ importers:
       '@types/react': ^17
       '@types/react-dom': ^17
       '@vanilla-extract/css': ^1.7.3
-      braid-design-system: 0.0.0-crackel2-20220901020334
+      braid-design-system: 0.0.0-crackel2-20220919072731
       react: 17.0.2
       react-dom: ^17.0.2
     dependencies:
       '@crackle/router': link:../../packages/router
       '@vanilla-extract/css': 1.9.0
-      braid-design-system: 0.0.0-crackel2-20220901020334_j6sw2p2tdbh6crpcmkxtmmhma4
+      braid-design-system: 0.0.0-crackel2-20220919072731_j6sw2p2tdbh6crpcmkxtmmhma4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -90,12 +90,12 @@ importers:
       '@crackle/router': workspace:*
       '@types/react': ^17
       '@types/react-dom': ^17
-      braid-design-system: 0.0.0-crackel2-20220901020334
+      braid-design-system: 0.0.0-crackel2-20220919072731
       react: 17.0.2
       react-dom: ^17.0.2
     dependencies:
       '@crackle/router': link:../../packages/router
-      braid-design-system: 0.0.0-crackel2-20220901020334_j6sw2p2tdbh6crpcmkxtmmhma4
+      braid-design-system: 0.0.0-crackel2-20220919072731_j6sw2p2tdbh6crpcmkxtmmhma4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -112,13 +112,13 @@ importers:
       '@types/react': ^17
       '@types/react-dom': ^17
       '@vanilla-extract/css': ^1.7.3
-      braid-design-system: 0.0.0-crackel2-20220901020334
+      braid-design-system: 0.0.0-crackel2-20220919072731
       react: 17.0.2
       react-dom: ^17.0.2
     dependencies:
       '@crackle-fixtures/multi-entry-library': link:../multi-entry-library
       '@vanilla-extract/css': 1.9.0
-      braid-design-system: 0.0.0-crackel2-20220901020334_j6sw2p2tdbh6crpcmkxtmmhma4
+      braid-design-system: 0.0.0-crackel2-20220919072731_j6sw2p2tdbh6crpcmkxtmmhma4
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
@@ -1904,11 +1904,11 @@ packages:
       - supports-color
     dev: false
 
-  /@crackle/cli/0.7.0_@types+react@17.0.49:
-    resolution: {integrity: sha512-rNjYAYjJSMWoX3NGL3s6kOrYlqdzge+LsdzRXZi5jgDjc89cXFkFlQzaed5Bl8qcaUydFnLhSrdsowMIByhr9Q==}
+  /@crackle/cli/0.8.0_@types+react@17.0.49:
+    resolution: {integrity: sha512-Mffu8jS9yegy2Cb1BkCgxMj0ogBrBDRYkjtL3KR13DKutZDXKE18jSO5DW8nc2RRHGz15HTx6alzuOEKolBh2w==}
     hasBin: true
     dependencies:
-      '@crackle/core': 0.10.3_@types+react@17.0.49
+      '@crackle/core': 0.11.0_@types+react@17.0.49
       yargs: 17.5.1
     transitivePeerDependencies:
       - '@types/react'
@@ -1917,23 +1917,29 @@ packages:
       - sass
       - stylus
       - supports-color
+      - terser
       - ts-node
+      - typescript
       - utf-8-validate
     dev: false
 
-  /@crackle/core/0.10.3_@types+react@17.0.49:
-    resolution: {integrity: sha512-jL8Heeaaq9PwaS5lBy3PJM9gxQB1l3FT/vG2A5XGGnbGnBZ9mPrRXWjaP71eJH/rz4VHd8niuSX+dQw1mFk2rQ==}
+  /@crackle/core/0.11.0_@types+react@17.0.49:
+    resolution: {integrity: sha512-0RrOroHiJ/5NiypOYmzHB88CJk8eNK59ZtwYi1DY8Q3CjLKrY7AYSKLAlulNT2ocIFyVShbp3Ln/7TO5ZTpStw==}
+    peerDependencies:
+      typescript: ~4.7.4
     dependencies:
       '@babel/core': 7.19.0
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.19.0
       '@babel/plugin-syntax-typescript': 7.18.6_@babel+core@7.19.0
       '@crackle/babel-plugin-remove-exports': 0.1.0
       '@crackle/router': 0.1.2_rucwy2ro6yyrjn73fut3quomqm
+      '@rollup/plugin-commonjs': 22.0.2_rollup@2.77.3
+      '@rollup/plugin-node-resolve': 13.3.0_rollup@2.77.3
       '@vanilla-extract/babel-plugin': 1.2.0
       '@vanilla-extract/css': 1.9.0
-      '@vanilla-extract/integration': 1.4.3
-      '@vanilla-extract/vite-plugin': 3.3.1_vite@2.9.15
-      '@vitejs/plugin-react-refresh': 1.3.6
+      '@vanilla-extract/integration': 5.0.1
+      '@vanilla-extract/vite-plugin': 3.3.1_vite@3.1.0
+      '@vitejs/plugin-react': 2.1.0_vite@3.1.0
       builtin-modules: 3.3.0
       chalk: 4.1.2
       ensure-gitignore: 1.2.0
@@ -1944,20 +1950,22 @@ packages:
       fs-extra: 10.1.0
       history: 5.3.0
       ink: 3.2.0_t4v2ig6j532zggk4vxuuplsqcq
+      mlly: 0.5.14
       normalize-path: 3.0.0
       parse-json: 5.2.0
       pretty-ms: 7.0.1
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
       resolve-from: 5.0.0
-      rollup-plugin-node-externals: 2.2.0_builtin-modules@3.3.0
+      rollup: 2.77.3
+      rollup-plugin-dts: 4.2.2_rollup@2.77.3
+      rollup-plugin-esbuild: 4.10.1_6jilvjhpmmtushjgfymgvmpv4q
+      rollup-plugin-node-externals: 4.1.1_rollup@2.77.3
       serialize-javascript: 6.0.0
       serve-handler: 6.1.3
       sort-package-json: 1.57.0
-      typescript: 4.7.4
       used-styles: 2.4.1
-      vite: 2.9.15
-      yarn-deduplicate: 3.1.0
+      vite: 3.1.0
     transitivePeerDependencies:
       - '@types/react'
       - bufferutil
@@ -1965,6 +1973,7 @@ packages:
       - sass
       - stylus
       - supports-color
+      - terser
       - ts-node
       - utf-8-validate
     dev: false
@@ -1982,15 +1991,6 @@ packages:
   /@emotion/hash/0.8.0:
     resolution: {integrity: sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow==}
     dev: false
-
-  /@esbuild/linux-loong64/0.14.54:
-    resolution: {integrity: sha512-bZBrLAIX1kpWelV0XemxBZllyRmM6vgFQQG2GdNb+r3Fkp0FOh1NJSvekXDs7jq70k4euu1cryLMfU+mTXlEpw==}
-    engines: {node: '>=12'}
-    cpu: [loong64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
 
   /@esbuild/linux-loong64/0.15.7:
     resolution: {integrity: sha512-IKznSJOsVUuyt7cDzzSZyqBEcZe+7WlBqTVXiF1OXP/4Nm387ToaXZ0fyLwI1iBlI/bzpxVq411QE2/Bt2XWWw==}
@@ -2322,6 +2322,22 @@ packages:
       rollup: 2.79.0
     dev: false
 
+  /@rollup/plugin-commonjs/22.0.2_rollup@2.77.3:
+    resolution: {integrity: sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      rollup: ^2.68.0
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.77.3
+      commondir: 1.0.1
+      estree-walker: 2.0.2
+      glob: 7.2.3
+      is-reference: 1.2.1
+      magic-string: 0.25.9
+      resolve: 1.22.1
+      rollup: 2.77.3
+    dev: false
+
   /@rollup/plugin-commonjs/22.0.2_rollup@2.78.1:
     resolution: {integrity: sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==}
     engines: {node: '>= 12.0.0'}
@@ -2362,6 +2378,21 @@ packages:
       rollup: 2.79.0
     dev: false
 
+  /@rollup/plugin-node-resolve/13.3.0_rollup@2.77.3:
+    resolution: {integrity: sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==}
+    engines: {node: '>= 10.0.0'}
+    peerDependencies:
+      rollup: ^2.42.0
+    dependencies:
+      '@rollup/pluginutils': 3.1.0_rollup@2.77.3
+      '@types/resolve': 1.17.1
+      deepmerge: 4.2.2
+      is-builtin-module: 3.2.0
+      is-module: 1.0.0
+      resolve: 1.22.1
+      rollup: 2.77.3
+    dev: false
+
   /@rollup/plugin-node-resolve/13.3.0_rollup@2.78.1:
     resolution: {integrity: sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==}
     engines: {node: '>= 10.0.0'}
@@ -2385,6 +2416,18 @@ packages:
       '@rollup/pluginutils': 3.1.0_rollup@2.79.0
       magic-string: 0.25.9
       rollup: 2.79.0
+    dev: false
+
+  /@rollup/pluginutils/3.1.0_rollup@2.77.3:
+    resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
+    engines: {node: '>= 8.0.0'}
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
+    dependencies:
+      '@types/estree': 0.0.39
+      estree-walker: 1.0.1
+      picomatch: 2.3.1
+      rollup: 2.77.3
     dev: false
 
   /@rollup/pluginutils/3.1.0_rollup@2.78.1:
@@ -2838,19 +2881,6 @@ packages:
       outdent: 0.8.0
     dev: false
 
-  /@vanilla-extract/integration/1.4.3:
-    resolution: {integrity: sha512-Jax0lADpx8LYwwOyiob9+koGm3H4xSMkWOD+pGTeI87YquALUcp9tqlhZOSPX3X5Jdlpyw2Gxxmo6wa47UEWHA==}
-    dependencies:
-      '@vanilla-extract/css': 1.9.0
-      chalk: 4.1.2
-      esbuild: 0.11.23
-      eval: 0.1.8
-      find-up: 5.0.0
-      javascript-stringify: 2.1.0
-      lodash: 4.17.21
-      outdent: 0.8.0
-    dev: false
-
   /@vanilla-extract/integration/5.0.1:
     resolution: {integrity: sha512-HRV/HvC/lihb9wT3x5s7pf5qLjqxSd9nBePJ10juOuMB5cl2ZClEcts076m9BuRKM3wRK2h7KuwkNsaUtjujxQ==}
     dependencies:
@@ -2875,20 +2905,6 @@ packages:
       '@vanilla-extract/css': 1.9.0
     dev: false
 
-  /@vanilla-extract/vite-plugin/3.3.1_vite@2.9.15:
-    resolution: {integrity: sha512-x5tl1s7uELTKU5HDMrZB9zDW7z+rcTuiT+sGPJ5/OOb+DHS4Y5S8caXOEytk/lhGegBS2gib4fN7yaJ0azuJlQ==}
-    peerDependencies:
-      vite: ^2.2.3
-    dependencies:
-      '@vanilla-extract/integration': 5.0.1
-      outdent: 0.8.0
-      postcss: 8.4.16
-      postcss-load-config: 3.1.4_postcss@8.4.16
-      vite: 2.9.15
-    transitivePeerDependencies:
-      - ts-node
-    dev: false
-
   /@vanilla-extract/vite-plugin/3.3.1_vite@3.1.0:
     resolution: {integrity: sha512-x5tl1s7uELTKU5HDMrZB9zDW7z+rcTuiT+sGPJ5/OOb+DHS4Y5S8caXOEytk/lhGegBS2gib4fN7yaJ0azuJlQ==}
     peerDependencies:
@@ -2901,20 +2917,6 @@ packages:
       vite: 3.1.0
     transitivePeerDependencies:
       - ts-node
-    dev: false
-
-  /@vitejs/plugin-react-refresh/1.3.6:
-    resolution: {integrity: sha512-iNR/UqhUOmFFxiezt0em9CgmiJBdWR+5jGxB2FihaoJfqGt76kiwaKoVOJVU5NYcDWMdN06LbyN2VIGIoYdsEA==}
-    engines: {node: '>=12.0.0'}
-    deprecated: This package has been deprecated in favor of @vitejs/plugin-react
-    dependencies:
-      '@babel/core': 7.19.0
-      '@babel/plugin-transform-react-jsx-self': 7.18.6_@babel+core@7.19.0
-      '@babel/plugin-transform-react-jsx-source': 7.18.6_@babel+core@7.19.0
-      '@rollup/pluginutils': 4.2.1
-      react-refresh: 0.10.0
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@vitejs/plugin-react/2.1.0_vite@3.1.0:
@@ -2933,10 +2935,6 @@ packages:
       vite: 3.1.0
     transitivePeerDependencies:
       - supports-color
-    dev: false
-
-  /@yarnpkg/lockfile/1.1.0:
-    resolution: {integrity: sha512-GpSwvyXOcOOlV70vbnzjj4fW5xW/FdUF6nQEt1ENy7m4ZCczi1+/buVUPAqmGfqznsORNFzUMjctTIp8a9tuCQ==}
     dev: false
 
   /accepts/1.3.8:
@@ -3240,8 +3238,8 @@ packages:
     dependencies:
       fill-range: 7.0.1
 
-  /braid-design-system/0.0.0-crackel2-20220901020334_j6sw2p2tdbh6crpcmkxtmmhma4:
-    resolution: {integrity: sha512-ZiVEZ/hAR6MKQi8+0eSi7S+80GZdh13Ngd0tfeawz1O8eCKhw4PSuAgKh0hQbZT9nh00nGrGbVY57XVpMcmcCA==}
+  /braid-design-system/0.0.0-crackel2-20220919072731_j6sw2p2tdbh6crpcmkxtmmhma4:
+    resolution: {integrity: sha512-6vUrkA02+yX/Mcj0/1j86vECO8cOGQkSP/+7XInOMuq5B4941TkYOaI929m0IbiWXpgLt7Fkpi8LYdAnoM7UtQ==}
     hasBin: true
     peerDependencies:
       react: ^16.8.0 || ^17 || ^18
@@ -3250,7 +3248,7 @@ packages:
     dependencies:
       '@capsizecss/core': 3.0.0
       '@capsizecss/vanilla-extract': 1.0.0_@vanilla-extract+css@1.9.0
-      '@crackle/cli': 0.7.0_@types+react@17.0.49
+      '@crackle/cli': 0.8.0_@types+react@17.0.49
       '@types/autosuggest-highlight': 3.2.0
       '@types/dedent': 0.7.0
       '@vanilla-extract/css': 1.9.0
@@ -3279,7 +3277,9 @@ packages:
       - sass
       - stylus
       - supports-color
+      - terser
       - ts-node
+      - typescript
       - utf-8-validate
     dev: false
 
@@ -3465,11 +3465,6 @@ packages:
 
   /commander/2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
-    dev: false
-
-  /commander/6.2.1:
-    resolution: {integrity: sha512-U7VdrJFnJgo4xjrHpTzu0yrHPGImdsmD95ZlgYSEajAn2JKzDhDTPG9kBTefmObL2w/ngeZnilk+OV9CG3d7UA==}
-    engines: {node: '>= 6'}
     dev: false
 
   /commondir/1.0.1:
@@ -3823,30 +3818,12 @@ packages:
     resolution: {integrity: sha512-MEl9uirslVwqQU369iHNWZXsI8yaZYGg/D65aOgZkeyFJwHYSxilf7rQzXKI7DdDuBPrBXbfk3sl9hJhmd5AUw==}
     dev: false
 
-  /esbuild-android-64/0.14.54:
-    resolution: {integrity: sha512-Tz2++Aqqz0rJ7kYBfz+iqyE3QMycD4vk7LBRyWaAVFgFtQ/O8EJOnVmTOiDWYZ/uYzB4kvP+bqejYdVKzE5lAQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [android]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /esbuild-android-64/0.15.7:
     resolution: {integrity: sha512-p7rCvdsldhxQr3YHxptf1Jcd86dlhvc3EQmQJaZzzuAxefO9PvcI0GLOa5nCWem1AJ8iMRu9w0r5TG8pHmbi9w==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [android]
     requiresBuild: true
-    optional: true
-
-  /esbuild-android-arm64/0.14.54:
-    resolution: {integrity: sha512-F9E+/QDi9sSkLaClO8SOV6etqPd+5DgJje1F9lOWoNncDdOBL2YF59IhsWATSt0TLZbYCf3pNlTHvVV5VfHdvg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [android]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-android-arm64/0.15.7:
@@ -3857,30 +3834,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-darwin-64/0.14.54:
-    resolution: {integrity: sha512-jtdKWV3nBviOd5v4hOpkVmpxsBy90CGzebpbO9beiqUYVMBtSc0AL9zGftFuBon7PNDcdvNCEuQqw2x0wP9yug==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /esbuild-darwin-64/0.15.7:
     resolution: {integrity: sha512-KGPt3r1c9ww009t2xLB6Vk0YyNOXh7hbjZ3EecHoVDxgtbUlYstMPDaReimKe6eOEfyY4hBEEeTvKwPsiH5WZg==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [darwin]
     requiresBuild: true
-    optional: true
-
-  /esbuild-darwin-arm64/0.14.54:
-    resolution: {integrity: sha512-OPafJHD2oUPyvJMrsCvDGkRrVCar5aVyHfWGQzY1dWnzErjrDuSETxwA2HSsyg2jORLY8yBfzc1MIpUkXlctmw==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [darwin]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-darwin-arm64/0.15.7:
@@ -3891,30 +3850,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-freebsd-64/0.14.54:
-    resolution: {integrity: sha512-OKwd4gmwHqOTp4mOGZKe/XUlbDJ4Q9TjX0hMPIDBUWWu/kwhBAudJdBoxnjNf9ocIB6GN6CPowYpR/hRCbSYAg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /esbuild-freebsd-64/0.15.7:
     resolution: {integrity: sha512-hESZB91qDLV5MEwNxzMxPfbjAhOmtfsr9Wnuci7pY6TtEh4UDuevmGmkUIjX/b+e/k4tcNBMf7SRQ2mdNuK/HQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [freebsd]
     requiresBuild: true
-    optional: true
-
-  /esbuild-freebsd-arm64/0.14.54:
-    resolution: {integrity: sha512-sFwueGr7OvIFiQT6WeG0jRLjkjdqWWSrfbVwZp8iMP+8UHEHRBvlaxL6IuKNDwAozNUmbb8nIMXa7oAOARGs1Q==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [freebsd]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-freebsd-arm64/0.15.7:
@@ -3925,30 +3866,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-32/0.14.54:
-    resolution: {integrity: sha512-1ZuY+JDI//WmklKlBgJnglpUL1owm2OX+8E1syCD6UAxcMM/XoWd76OHSjl/0MR0LisSAXDqgjT3uJqT67O3qw==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /esbuild-linux-32/0.15.7:
     resolution: {integrity: sha512-v3gT/LsONGUZcjbt2swrMjwxo32NJzk+7sAgtxhGx1+ZmOFaTRXBAi1PPfgpeo/J//Un2jIKm/I+qqeo4caJvg==}
     engines: {node: '>=12'}
     cpu: [ia32]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /esbuild-linux-64/0.14.54:
-    resolution: {integrity: sha512-EgjAgH5HwTbtNsTqQOXWApBaPVdDn7XcK+/PtJwZLT1UmpLoznPd8c5CxqsH2dQK3j05YsB3L17T8vE7cp4cCg==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-64/0.15.7:
@@ -3959,30 +3882,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-arm/0.14.54:
-    resolution: {integrity: sha512-qqz/SjemQhVMTnvcLGoLOdFpCYbz4v4fUo+TfsWG+1aOu70/80RV6bgNpR2JCrppV2moUQkww+6bWxXRL9YMGw==}
-    engines: {node: '>=12'}
-    cpu: [arm]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /esbuild-linux-arm/0.15.7:
     resolution: {integrity: sha512-JKgAHtMR5f75wJTeuNQbyznZZa+pjiUHV7sRZp42UNdyXC6TiUYMW/8z8yIBAr2Fpad8hM1royZKQisqPABPvQ==}
     engines: {node: '>=12'}
     cpu: [arm]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /esbuild-linux-arm64/0.14.54:
-    resolution: {integrity: sha512-WL71L+0Rwv+Gv/HTmxTEmpv0UgmxYa5ftZILVi2QmZBgX3q7+tDeOQNqGtdXSdsL8TQi1vIaVFHUPDe0O0kdig==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-arm64/0.15.7:
@@ -3993,30 +3898,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-mips64le/0.14.54:
-    resolution: {integrity: sha512-qTHGQB8D1etd0u1+sB6p0ikLKRVuCWhYQhAHRPkO+OF3I/iSlTKNNS0Lh2Oc0g0UFGguaFZZiPJdJey3AGpAlw==}
-    engines: {node: '>=12'}
-    cpu: [mips64el]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /esbuild-linux-mips64le/0.15.7:
     resolution: {integrity: sha512-T7XKuxl0VpeFLCJXub6U+iybiqh0kM/bWOTb4qcPyDDwNVhLUiPcGdG2/0S7F93czUZOKP57YiLV8YQewgLHKw==}
     engines: {node: '>=12'}
     cpu: [mips64el]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /esbuild-linux-ppc64le/0.14.54:
-    resolution: {integrity: sha512-j3OMlzHiqwZBDPRCDFKcx595XVfOfOnv68Ax3U4UKZ3MTYQB5Yz3X1mn5GnodEVYzhtZgxEBidLWeIs8FDSfrQ==}
-    engines: {node: '>=12'}
-    cpu: [ppc64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-ppc64le/0.15.7:
@@ -4027,30 +3914,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-linux-riscv64/0.14.54:
-    resolution: {integrity: sha512-y7Vt7Wl9dkOGZjxQZnDAqqn+XOqFD7IMWiewY5SPlNlzMX39ocPQlOaoxvT4FllA5viyV26/QzHtvTjVNOxHZg==}
-    engines: {node: '>=12'}
-    cpu: [riscv64]
-    os: [linux]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /esbuild-linux-riscv64/0.15.7:
     resolution: {integrity: sha512-uUJsezbswAYo/X7OU/P+PuL/EI9WzxsEQXDekfwpQ23uGiooxqoLFAPmXPcRAt941vjlY9jtITEEikWMBr+F/g==}
     engines: {node: '>=12'}
     cpu: [riscv64]
     os: [linux]
     requiresBuild: true
-    optional: true
-
-  /esbuild-linux-s390x/0.14.54:
-    resolution: {integrity: sha512-zaHpW9dziAsi7lRcyV4r8dhfG1qBidQWUXweUjnw+lliChJqQr+6XD71K41oEIC3Mx1KStovEmlzm+MkGZHnHA==}
-    engines: {node: '>=12'}
-    cpu: [s390x]
-    os: [linux]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-linux-s390x/0.15.7:
@@ -4061,30 +3930,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-netbsd-64/0.14.54:
-    resolution: {integrity: sha512-PR01lmIMnfJTgeU9VJTDY9ZerDWVFIUzAtJuDHwwceppW7cQWjBBqP48NdeRtoP04/AtO9a7w3viI+PIDr6d+w==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [netbsd]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /esbuild-netbsd-64/0.15.7:
     resolution: {integrity: sha512-yVc4Wz+Pu3cP5hzm5kIygNPrjar/v5WCSoRmIjCPWfBVJkZNb5brEGKUlf+0Y759D48BCWa0WHrWXaNy0DULTQ==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [netbsd]
     requiresBuild: true
-    optional: true
-
-  /esbuild-openbsd-64/0.14.54:
-    resolution: {integrity: sha512-Qyk7ikT2o7Wu76UsvvDS5q0amJvmRzDyVlL0qf5VLsLchjCa1+IAvd8kTBgUxD7VBUUVgItLkk609ZHUc1oCaw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [openbsd]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-openbsd-64/0.15.7:
@@ -4095,30 +3946,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-sunos-64/0.14.54:
-    resolution: {integrity: sha512-28GZ24KmMSeKi5ueWzMcco6EBHStL3B6ubM7M51RmPwXQGLe0teBGJocmWhgwccA1GeFXqxzILIxXpHbl9Q/Kw==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [sunos]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /esbuild-sunos-64/0.15.7:
     resolution: {integrity: sha512-8CDI1aL/ts0mDGbWzjEOGKXnU7p3rDzggHSBtVryQzkSOsjCHRVe0iFYUuhczlxU1R3LN/E7HgUO4NXzGGP/Ag==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [sunos]
     requiresBuild: true
-    optional: true
-
-  /esbuild-windows-32/0.14.54:
-    resolution: {integrity: sha512-T+rdZW19ql9MjS7pixmZYVObd9G7kcaZo+sETqNH4RCkuuYSuv9AGHUVnPoP9hhuE1WM1ZimHz1CIBHBboLU7w==}
-    engines: {node: '>=12'}
-    cpu: [ia32]
-    os: [win32]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-windows-32/0.15.7:
@@ -4129,30 +3962,12 @@ packages:
     requiresBuild: true
     optional: true
 
-  /esbuild-windows-64/0.14.54:
-    resolution: {integrity: sha512-AoHTRBUuYwXtZhjXZbA1pGfTo8cJo3vZIcWGLiUcTNgHpJJMC1rVA44ZereBHMJtotyN71S8Qw0npiCIkW96cQ==}
-    engines: {node: '>=12'}
-    cpu: [x64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
-    optional: true
-
   /esbuild-windows-64/0.15.7:
     resolution: {integrity: sha512-7MI08Ec2sTIDv+zH6StNBKO+2hGUYIT42GmFyW6MBBWWtJhTcQLinKS6ldIN1d52MXIbiJ6nXyCJ+LpL4jBm3Q==}
     engines: {node: '>=12'}
     cpu: [x64]
     os: [win32]
     requiresBuild: true
-    optional: true
-
-  /esbuild-windows-arm64/0.14.54:
-    resolution: {integrity: sha512-M0kuUvXhot1zOISQGXwWn6YtS+Y/1RT9WrVIOywZnJHo3jCDyewAc79aKNQWFCQm+xNHVTq9h8dZKvygoXQQRg==}
-    engines: {node: '>=12'}
-    cpu: [arm64]
-    os: [win32]
-    requiresBuild: true
-    dev: false
     optional: true
 
   /esbuild-windows-arm64/0.15.7:
@@ -4167,35 +3982,6 @@ packages:
     resolution: {integrity: sha512-iaiZZ9vUF5wJV8ob1tl+5aJTrwDczlvGP0JoMmnpC2B0ppiMCu8n8gmy5ZTGl5bcG081XBVn+U+jP+mPFm5T5Q==}
     hasBin: true
     requiresBuild: true
-    dev: false
-
-  /esbuild/0.14.54:
-    resolution: {integrity: sha512-Cy9llcy8DvET5uznocPyqL3BFRrFXSVqbgpMJ9Wz8oVjZlh/zUSNbPRbov0VX7VxN2JH1Oa0uNxZ7eLRb62pJA==}
-    engines: {node: '>=12'}
-    hasBin: true
-    requiresBuild: true
-    optionalDependencies:
-      '@esbuild/linux-loong64': 0.14.54
-      esbuild-android-64: 0.14.54
-      esbuild-android-arm64: 0.14.54
-      esbuild-darwin-64: 0.14.54
-      esbuild-darwin-arm64: 0.14.54
-      esbuild-freebsd-64: 0.14.54
-      esbuild-freebsd-arm64: 0.14.54
-      esbuild-linux-32: 0.14.54
-      esbuild-linux-64: 0.14.54
-      esbuild-linux-arm: 0.14.54
-      esbuild-linux-arm64: 0.14.54
-      esbuild-linux-mips64le: 0.14.54
-      esbuild-linux-ppc64le: 0.14.54
-      esbuild-linux-riscv64: 0.14.54
-      esbuild-linux-s390x: 0.14.54
-      esbuild-netbsd-64: 0.14.54
-      esbuild-openbsd-64: 0.14.54
-      esbuild-sunos-64: 0.14.54
-      esbuild-windows-32: 0.14.54
-      esbuild-windows-64: 0.14.54
-      esbuild-windows-arm64: 0.14.54
     dev: false
 
   /esbuild/0.15.7:
@@ -6641,11 +6427,6 @@ packages:
       scheduler: 0.20.2
     dev: false
 
-  /react-refresh/0.10.0:
-    resolution: {integrity: sha512-PgidR3wST3dDYKr6b4pJoqQFpPGNKDSCDx4cZoshjXipw3LzO7mG1My2pwEzz2JVkF+inx3xRpDeQLFQGH/hsQ==}
-    engines: {node: '>=0.10.0'}
-    dev: false
-
   /react-refresh/0.14.0:
     resolution: {integrity: sha512-wViHqhAd8OHeLS/IRMJjTSDHF3U9eWi62F/MledQGPdJGDhodXJ9PBLNGr6WWL7qlH12Mt3TyTpbS+hGXMjCzQ==}
     engines: {node: '>=0.10.0'}
@@ -6914,6 +6695,19 @@ packages:
       glob: 7.2.3
     dev: true
 
+  /rollup-plugin-dts/4.2.2_rollup@2.77.3:
+    resolution: {integrity: sha512-A3g6Rogyko/PXeKoUlkjxkP++8UDVpgA7C+Tdl77Xj4fgEaIjPSnxRmR53EzvoYy97VMVwLAOcWJudaVAuxneQ==}
+    engines: {node: '>=v12.22.11'}
+    peerDependencies:
+      rollup: ^2.55
+      typescript: ^4.1
+    dependencies:
+      magic-string: 0.26.3
+      rollup: 2.77.3
+    optionalDependencies:
+      '@babel/code-frame': 7.18.6
+    dev: false
+
   /rollup-plugin-dts/4.2.2_rollup@2.78.1:
     resolution: {integrity: sha512-A3g6Rogyko/PXeKoUlkjxkP++8UDVpgA7C+Tdl77Xj4fgEaIjPSnxRmR53EzvoYy97VMVwLAOcWJudaVAuxneQ==}
     engines: {node: '>=v12.22.11'}
@@ -6945,14 +6739,32 @@ packages:
       - supports-color
     dev: false
 
-  /rollup-plugin-node-externals/2.2.0_builtin-modules@3.3.0:
-    resolution: {integrity: sha512-WM7TtQ76GdsLceEGmZzQzn1afj8JgOQT5VLs1Y9RMqowM/8eK2mBj/Lv7hoE833U75QsUZIRirYUtFatu51RJA==}
-    engines: {node: '>=8.0.0'}
+  /rollup-plugin-esbuild/4.10.1_6jilvjhpmmtushjgfymgvmpv4q:
+    resolution: {integrity: sha512-/ymcRB283zjFp1JTBXO8ekxv0c9vRc2L6OTljghsLthQ4vqeDSDWa9BVz1tHiVrx6SbUnUpDPLC0K/MXK7j5TA==}
+    engines: {node: '>=12'}
     peerDependencies:
-      builtin-modules: ^3.1.0
+      esbuild: '>=0.10.1'
+      rollup: ^1.20.0 || ^2.0.0
     dependencies:
-      builtin-modules: 3.3.0
-      find-up: 4.1.0
+      '@rollup/pluginutils': 4.2.1
+      debug: 4.3.4
+      es-module-lexer: 0.9.3
+      esbuild: 0.15.7
+      joycon: 3.1.1
+      jsonc-parser: 3.2.0
+      rollup: 2.77.3
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /rollup-plugin-node-externals/4.1.1_rollup@2.77.3:
+    resolution: {integrity: sha512-hiGCMTKHVoueaTmtcUv1KR0/dlNBuI9GYzHUlSHQbMd7T7yomYdXCFnBisoBqdZYy61EGAIfz8AvJaWWBho3Pg==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      rollup: ^2.60.0
+    dependencies:
+      find-up: 5.0.0
+      rollup: 2.77.3
     dev: false
 
   /rollup-plugin-node-externals/4.1.1_rollup@2.78.1:
@@ -7708,30 +7520,6 @@ packages:
     engines: {node: '>= 0.8'}
     dev: false
 
-  /vite/2.9.15:
-    resolution: {integrity: sha512-fzMt2jK4vQ3yK56te3Kqpkaeq9DkcZfBbzHwYpobasvgYmP2SoAr6Aic05CsB4CzCZbsDv4sujX3pkEGhLabVQ==}
-    engines: {node: '>=12.2.0'}
-    hasBin: true
-    peerDependencies:
-      less: '*'
-      sass: '*'
-      stylus: '*'
-    peerDependenciesMeta:
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-    dependencies:
-      esbuild: 0.14.54
-      postcss: 8.4.16
-      resolve: 1.22.1
-      rollup: 2.77.3
-    optionalDependencies:
-      fsevents: 2.3.2
-    dev: false
-
   /vite/3.1.0:
     resolution: {integrity: sha512-YBg3dUicDpDWFCGttmvMbVyS9ydjntwEjwXRj2KBFwSB8SxmGcudo1yb8FW5+M/G86aS8x828ujnzUVdsLjs9g==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -8001,16 +7789,6 @@ packages:
       string-width: 4.2.3
       y18n: 5.0.8
       yargs-parser: 21.1.1
-    dev: false
-
-  /yarn-deduplicate/3.1.0:
-    resolution: {integrity: sha512-q2VZ6ThNzQpGfNpkPrkmV7x5HT9MOhCUsTxVTzyyZB0eSXz1NTodHn+r29DlLb+peKk8iXxzdUVhQG9pI7moFw==}
-    engines: {node: '>=10', yarn: '>=1'}
-    hasBin: true
-    dependencies:
-      '@yarnpkg/lockfile': 1.1.0
-      commander: 6.2.1
-      semver: 7.3.7
     dev: false
 
   /yocto-queue/0.1.0:


### PR DESCRIPTION
- Added a `clean` config option (and Add a `--clean` CLI argument) to clean the output directory on `crackle package`.
- Added a `dtsOptions` config option to [override the default](https://github.com/Swatinem/rollup-plugin-dts/blob/660af866d1d76401dc0b66b48eeb7ff1521ffdaf/src/program.ts#L12-L28) TypeScript `compilerOptions` for `.d.ts` bundle generation.
  - `noEmitOnError` prevents Braid from being bundled, with a benign error:
      ```
      "RefAttributes" is imported from external module "react" but never used in <long list of files>
      ```
  - `incremental` prevents Vanilla Extract from being bundled
- Refactored how `package.json#exports` are generated. An important note here:
  - Changed the extension for generated ESM bundles from `.mjs` to `.esm.js` because Braid imports "broken" entry points (i.e. the likes of `lodash/mapValues` and `autosuggest-highlight/parse`) and Webpack crashes when building the Braid site.
    - @mattcompiles suggested we write our own resolution plugin similar to Vite's
- Unified the output path resolution logic. There were many places where `dist` was hardcoded, now it's all done in one place (there are some exceptions).
- When bunding for `.d.ts` each entry is bundled separately to avoid chunking. Because `@vanilla-extract/css` is a dependency of `braid-design-system` then a reference to a Vanilla Extract `.d.ts` chunk might end up in the Braid `.d.ts` bundle but the hash can change when Vanilla Extract is updated.