### PR TITLE
Use `.js` extension instead of `.esm.js` for compiled artifacts

### DIFF
--- a/.changeset/moody-cars-camp.md
+++ b/.changeset/moody-cars-camp.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': patch
+---
+
+Use .mjs file extension for compiled artifacts

--- a/.changeset/moody-cars-camp.md
+++ b/.changeset/moody-cars-camp.md
@@ -2,4 +2,4 @@
 '@crackle/core': patch
 ---
 
-Use .mjs file extension for compiled artifacts
+Use `.js` file extension for compiled artifacts

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -28,12 +28,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build
-        run: |
-          pnpm fix
-          pnpm build
+        run: pnpm build
 
       - name: Set up fixtures
-        run: pnpm fixtures dev
+        run: pnpm fixtures package
 
       - name: Lint
         run: pnpm lint

--- a/fixtures/braid-site/package.json
+++ b/fixtures/braid-site/package.json
@@ -12,6 +12,7 @@
     "start": "crackle start"
   },
   "dependencies": {
+    "@crackle-fixtures/library-with-docs": "workspace:*",
     "@crackle/router": "workspace:*",
     "@vanilla-extract/css": "^1.7.3",
     "braid-design-system": "0.0.0-crackel2-20220919072731",

--- a/fixtures/braid-site/package.json
+++ b/fixtures/braid-site/package.json
@@ -12,8 +12,8 @@
     "start": "crackle start"
   },
   "dependencies": {
-    "@crackle-fixtures/library-with-docs": "workspace:*",
-    "@crackle/router": "workspace:*",
+    "@crackle-fixtures/library-with-docs": "*",
+    "@crackle/router": "*",
     "@vanilla-extract/css": "^1.7.3",
     "braid-design-system": "0.0.0-crackel2-20220919072731",
     "react": "17.0.2",

--- a/fixtures/braid-site/src/home.page.tsx
+++ b/fixtures/braid-site/src/home.page.tsx
@@ -1,3 +1,4 @@
+import { JobSummary } from '@crackle-fixtures/library-with-docs';
 import { createRouteData } from '@crackle/router';
 import { Card, Stack, Text, TextLink } from 'braid-design-system';
 import React from 'react';
@@ -14,6 +15,7 @@ export default function Home() {
         <Text>
           <TextLink href="/details">Details</TextLink>
         </Text>
+        <JobSummary title="Job title" isNew />
       </Stack>
     </Card>
   );

--- a/fixtures/library-with-docs/.gitignore
+++ b/fixtures/library-with-docs/.gitignore
@@ -1,0 +1,3 @@
+# managed by crackle
+/dist
+# end managed by crackle

--- a/fixtures/library-with-docs/package.json
+++ b/fixtures/library-with-docs/package.json
@@ -8,12 +8,12 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.cjs.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
   "files": [
     "/dist"
   ],

--- a/fixtures/library-with-docs/package.json
+++ b/fixtures/library-with-docs/package.json
@@ -8,12 +8,12 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.cjs.d.ts",
-      "import": "./dist/index.mjs",
+      "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
   "files": [
     "/dist"
   ],

--- a/fixtures/library-with-docs/package.json
+++ b/fixtures/library-with-docs/package.json
@@ -28,12 +28,14 @@
     "@crackle/router": "workspace:*",
     "@vanilla-extract/css": "^1.7.3",
     "braid-design-system": "0.0.0-crackel2-20220919072731",
+    "lodash": "^4.17.21",
     "react": "17.0.2",
     "react-dom": "^17.0.2"
   },
   "devDependencies": {
     "@crackle/cli": "workspace:*",
     "@crackle/core": "workspace:*",
+    "@types/lodash": "^4.14.186",
     "@types/react": "^17",
     "@types/react-dom": "^17"
   }

--- a/fixtures/library-with-docs/src/components/JobSummary/JobSummary.tsx
+++ b/fixtures/library-with-docs/src/components/JobSummary/JobSummary.tsx
@@ -14,6 +14,7 @@ import {
   Stack,
   Text,
 } from 'braid-design-system';
+import values from 'lodash/values';
 import React from 'react';
 
 import { redBorder } from './styles.css';
@@ -57,7 +58,7 @@ export const JobSummary = ({ title, isNew }: JobSummaryProps) => (
           Long description of card details providing more information.
         </Text>
         <Text size="xsmall" tone="secondary">
-          2d ago
+          {values({ value: '2d', suffix: 'ago' }).join(' ')}
         </Text>
       </Stack>
     </Box>

--- a/fixtures/multi-entry-library/package.json
+++ b/fixtures/multi-entry-library/package.json
@@ -8,27 +8,27 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.cjs.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     },
     "./components": {
       "types": "./components/dist/index.cjs.d.ts",
-      "import": "./components/dist/index.esm.js",
+      "import": "./components/dist/index.js",
       "require": "./components/dist/index.cjs"
     },
     "./extras": {
       "types": "./extras/dist/index.cjs.d.ts",
-      "import": "./extras/dist/index.esm.js",
+      "import": "./extras/dist/index.js",
       "require": "./extras/dist/index.cjs"
     },
     "./themes/apac": {
       "types": "./themes/apac/dist/index.cjs.d.ts",
-      "import": "./themes/apac/dist/index.esm.js",
+      "import": "./themes/apac/dist/index.js",
       "require": "./themes/apac/dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.js",
   "files": [
     "/components",
     "/dist",

--- a/fixtures/single-entry-library/package.json
+++ b/fixtures/single-entry-library/package.json
@@ -8,12 +8,12 @@
     "./package.json": "./package.json",
     ".": {
       "types": "./dist/index.cjs.d.ts",
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.js",
       "require": "./dist/index.cjs"
     }
   },
   "main": "./dist/index.cjs",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.js",
   "files": [
     "/dist"
   ],

--- a/packages/core/src/utils/__snapshots__/setup-package-json.test.ts.snap
+++ b/packages/core/src/utils/__snapshots__/setup-package-json.test.ts.snap
@@ -10,7 +10,7 @@ exports[`diffPackageJson > Empty package.json > diffs 1`] = `
   {
     "from": undefined,
     "key": "module",
-    "to": "./dist/index.mjs",
+    "to": "./dist/index.js",
   },
   {
     "additions": [
@@ -30,18 +30,18 @@ exports[`diffPackageJson > Empty package.json > expectedPackageJson 1`] = `
 {
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
+      "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "types": "./dist/index.cjs.d.ts",
     },
     "./css": {
-      "import": "./css/dist/index.mjs",
+      "import": "./css/dist/index.js",
       "require": "./css/dist/index.cjs",
       "types": "./css/dist/index.cjs.d.ts",
     },
     "./package.json": "./package.json",
     "./themes/apac": {
-      "import": "./themes/apac/dist/index.mjs",
+      "import": "./themes/apac/dist/index.js",
       "require": "./themes/apac/dist/index.cjs",
       "types": "./themes/apac/dist/index.cjs.d.ts",
     },
@@ -52,7 +52,7 @@ exports[`diffPackageJson > Empty package.json > expectedPackageJson 1`] = `
     "/themes/apac",
   ],
   "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
 }
 `;
 
@@ -61,7 +61,7 @@ exports[`diffPackageJson > Incorrect package.json > diffs 1`] = `
   {
     "from": "dist/index.esm.invalid",
     "key": "module",
-    "to": "./dist/index.mjs",
+    "to": "./dist/index.js",
   },
   {
     "additions": [
@@ -79,18 +79,18 @@ exports[`diffPackageJson > Incorrect package.json > expectedPackageJson 1`] = `
 {
   "exports": {
     ".": {
-      "import": "./dist/index.mjs",
+      "import": "./dist/index.js",
       "require": "./dist/index.cjs",
       "types": "./dist/index.cjs.d.ts",
     },
     "./css": {
-      "import": "./css/dist/index.mjs",
+      "import": "./css/dist/index.js",
       "require": "./css/dist/index.cjs",
       "types": "./css/dist/index.cjs.d.ts",
     },
     "./package.json": "./package.json",
     "./themes/apac": {
-      "import": "./themes/apac/dist/index.mjs",
+      "import": "./themes/apac/dist/index.js",
       "require": "./themes/apac/dist/index.cjs",
       "types": "./themes/apac/dist/index.cjs.d.ts",
     },
@@ -102,6 +102,6 @@ exports[`diffPackageJson > Incorrect package.json > expectedPackageJson 1`] = `
     "/themes/apac",
   ],
   "main": "./dist/index.cjs",
-  "module": "./dist/index.mjs",
+  "module": "./dist/index.js",
 }
 `;

--- a/packages/core/src/utils/__snapshots__/setup-package-json.test.ts.snap
+++ b/packages/core/src/utils/__snapshots__/setup-package-json.test.ts.snap
@@ -10,7 +10,7 @@ exports[`diffPackageJson > Empty package.json > diffs 1`] = `
   {
     "from": undefined,
     "key": "module",
-    "to": "./dist/index.esm.js",
+    "to": "./dist/index.mjs",
   },
   {
     "additions": [
@@ -30,18 +30,18 @@ exports[`diffPackageJson > Empty package.json > expectedPackageJson 1`] = `
 {
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.cjs",
       "types": "./dist/index.cjs.d.ts",
     },
     "./css": {
-      "import": "./css/dist/index.esm.js",
+      "import": "./css/dist/index.mjs",
       "require": "./css/dist/index.cjs",
       "types": "./css/dist/index.cjs.d.ts",
     },
     "./package.json": "./package.json",
     "./themes/apac": {
-      "import": "./themes/apac/dist/index.esm.js",
+      "import": "./themes/apac/dist/index.mjs",
       "require": "./themes/apac/dist/index.cjs",
       "types": "./themes/apac/dist/index.cjs.d.ts",
     },
@@ -52,7 +52,7 @@ exports[`diffPackageJson > Empty package.json > expectedPackageJson 1`] = `
     "/themes/apac",
   ],
   "main": "./dist/index.cjs",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
 }
 `;
 
@@ -61,7 +61,7 @@ exports[`diffPackageJson > Incorrect package.json > diffs 1`] = `
   {
     "from": "dist/index.esm.invalid",
     "key": "module",
-    "to": "./dist/index.esm.js",
+    "to": "./dist/index.mjs",
   },
   {
     "additions": [
@@ -79,18 +79,18 @@ exports[`diffPackageJson > Incorrect package.json > expectedPackageJson 1`] = `
 {
   "exports": {
     ".": {
-      "import": "./dist/index.esm.js",
+      "import": "./dist/index.mjs",
       "require": "./dist/index.cjs",
       "types": "./dist/index.cjs.d.ts",
     },
     "./css": {
-      "import": "./css/dist/index.esm.js",
+      "import": "./css/dist/index.mjs",
       "require": "./css/dist/index.cjs",
       "types": "./css/dist/index.cjs.d.ts",
     },
     "./package.json": "./package.json",
     "./themes/apac": {
-      "import": "./themes/apac/dist/index.esm.js",
+      "import": "./themes/apac/dist/index.mjs",
       "require": "./themes/apac/dist/index.cjs",
       "types": "./themes/apac/dist/index.cjs.d.ts",
     },
@@ -102,6 +102,6 @@ exports[`diffPackageJson > Incorrect package.json > expectedPackageJson 1`] = `
     "/themes/apac",
   ],
   "main": "./dist/index.cjs",
-  "module": "./dist/index.esm.js",
+  "module": "./dist/index.mjs",
 }
 `;

--- a/packages/core/src/utils/files.ts
+++ b/packages/core/src/utils/files.ts
@@ -70,4 +70,4 @@ export const emptyDir = async (dir: string, skip = ['.git']): Promise<void> => {
 };
 
 export const extensionForFormat = (format: Format) =>
-  (({ esm: 'mjs', cjs: 'cjs', dts: 'cjs.d.ts' } as const)[format]);
+  (({ esm: 'js', cjs: 'cjs', dts: 'cjs.d.ts' } as const)[format]);

--- a/packages/core/src/utils/files.ts
+++ b/packages/core/src/utils/files.ts
@@ -70,4 +70,4 @@ export const emptyDir = async (dir: string, skip = ['.git']): Promise<void> => {
 };
 
 export const extensionForFormat = (format: Format) =>
-  (({ esm: 'esm.js', cjs: 'cjs', dts: 'cjs.d.ts' } as const)[format]);
+  (({ esm: 'mjs', cjs: 'cjs', dts: 'cjs.d.ts' } as const)[format]);

--- a/packages/core/src/utils/setup-package-json.test.ts
+++ b/packages/core/src/utils/setup-package-json.test.ts
@@ -46,7 +46,7 @@ describe('diffPackageJson', () => {
         exports: {
           '.': {
             import: {
-              default: './dist/index.mjs',
+              default: './dist/index.js',
               types: './dist/index.cjs.d.ts',
             },
             require: {
@@ -56,13 +56,13 @@ describe('diffPackageJson', () => {
           },
           './css': {
             types: './css/dist/index.cjs.d.ts',
-            import: './css/dist/index.mjs',
+            import: './css/dist/index.js',
             require: './css/dist/index.cjs',
           },
           './package.json': './package.json',
           './themes/apac': {
             types: './themes/apac/dist/index.cjs.d.ts',
-            import: './themes/apac/dist/index.mjs',
+            import: './themes/apac/dist/index.js',
             require: './themes/apac/dist/index.cjs',
           },
         },
@@ -83,24 +83,24 @@ describe('diffPackageJson', () => {
         exports: {
           '.': {
             types: './dist/index.cjs.d.ts',
-            import: './dist/index.mjs',
+            import: './dist/index.js',
             require: './dist/index.cjs',
           },
           './css': {
             types: './css/dist/index.cjs.d.ts',
-            import: './css/dist/index.mjs',
+            import: './css/dist/index.js',
             require: './css/dist/index.cjs',
           },
           './package.json': './package.json',
           './themes/apac': {
             types: './themes/apac/dist/index.cjs.d.ts',
-            import: './themes/apac/dist/index.mjs',
+            import: './themes/apac/dist/index.js',
             require: './themes/apac/dist/index.cjs',
           },
         },
         files: ['/css', '/dist', '/themes/apac'],
         main: './dist/index.cjs',
-        module: './dist/index.mjs',
+        module: './dist/index.js',
       },
       entries,
     );

--- a/packages/core/src/utils/setup-package-json.test.ts
+++ b/packages/core/src/utils/setup-package-json.test.ts
@@ -46,7 +46,7 @@ describe('diffPackageJson', () => {
         exports: {
           '.': {
             import: {
-              default: './dist/index.esm.js',
+              default: './dist/index.mjs',
               types: './dist/index.cjs.d.ts',
             },
             require: {
@@ -56,13 +56,13 @@ describe('diffPackageJson', () => {
           },
           './css': {
             types: './css/dist/index.cjs.d.ts',
-            import: './css/dist/index.esm.js',
+            import: './css/dist/index.mjs',
             require: './css/dist/index.cjs',
           },
           './package.json': './package.json',
           './themes/apac': {
             types: './themes/apac/dist/index.cjs.d.ts',
-            import: './themes/apac/dist/index.esm.js',
+            import: './themes/apac/dist/index.mjs',
             require: './themes/apac/dist/index.cjs',
           },
         },
@@ -83,24 +83,24 @@ describe('diffPackageJson', () => {
         exports: {
           '.': {
             types: './dist/index.cjs.d.ts',
-            import: './dist/index.esm.js',
+            import: './dist/index.mjs',
             require: './dist/index.cjs',
           },
           './css': {
             types: './css/dist/index.cjs.d.ts',
-            import: './css/dist/index.esm.js',
+            import: './css/dist/index.mjs',
             require: './css/dist/index.cjs',
           },
           './package.json': './package.json',
           './themes/apac': {
             types: './themes/apac/dist/index.cjs.d.ts',
-            import: './themes/apac/dist/index.esm.js',
+            import: './themes/apac/dist/index.mjs',
             require: './themes/apac/dist/index.cjs',
           },
         },
         files: ['/css', '/dist', '/themes/apac'],
         main: './dist/index.cjs',
-        module: './dist/index.esm.js',
+        module: './dist/index.mjs',
       },
       entries,
     );

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -67,21 +67,25 @@ importers:
       '@crackle/cli': workspace:*
       '@crackle/core': workspace:*
       '@crackle/router': workspace:*
+      '@types/lodash': ^4.14.186
       '@types/react': ^17
       '@types/react-dom': ^17
       '@vanilla-extract/css': ^1.7.3
       braid-design-system: 0.0.0-crackel2-20220919072731
+      lodash: ^4.17.21
       react: 17.0.2
       react-dom: ^17.0.2
     dependencies:
       '@crackle/router': link:../../packages/router
       '@vanilla-extract/css': 1.9.0
       braid-design-system: 0.0.0-crackel2-20220919072731_j6sw2p2tdbh6crpcmkxtmmhma4
+      lodash: 4.17.21
       react: 17.0.2
       react-dom: 17.0.2_react@17.0.2
     devDependencies:
       '@crackle/cli': link:../../packages/cli
       '@crackle/core': link:../../packages/core
+      '@types/lodash': 4.14.186
       '@types/react': 17.0.49
       '@types/react-dom': 17.0.17
 
@@ -2602,6 +2606,10 @@ packages:
 
   /@types/json5/0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
+    dev: true
+
+  /@types/lodash/4.14.186:
+    resolution: {integrity: sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==}
     dev: true
 
   /@types/mime/3.0.1:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,10 +39,10 @@ importers:
 
   fixtures/braid-site:
     specifiers:
-      '@crackle-fixtures/library-with-docs': workspace:*
+      '@crackle-fixtures/library-with-docs': '*'
       '@crackle/cli': workspace:*
       '@crackle/core': workspace:*
-      '@crackle/router': workspace:*
+      '@crackle/router': '*'
       '@types/react': ^17
       '@types/react-dom': ^17
       '@vanilla-extract/css': ^1.7.3

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -39,6 +39,7 @@ importers:
 
   fixtures/braid-site:
     specifiers:
+      '@crackle-fixtures/library-with-docs': workspace:*
       '@crackle/cli': workspace:*
       '@crackle/core': workspace:*
       '@crackle/router': workspace:*
@@ -49,6 +50,7 @@ importers:
       react: 17.0.2
       react-dom: ^17.0.2
     dependencies:
+      '@crackle-fixtures/library-with-docs': link:../library-with-docs
       '@crackle/router': link:../../packages/router
       '@vanilla-extract/css': 1.9.0
       braid-design-system: 0.0.0-crackel2-20220919072731_j6sw2p2tdbh6crpcmkxtmmhma4


### PR DESCRIPTION
✅ Working in Braid site with snapshot
✅ Working in `braid-site` fixture with Braid snapshot
✅ Working in Gotham site with Crackle and Braid snapshots