### PR TITLE
Misc fixes

### DIFF
--- a/.changeset/modern-poems-attack.md
+++ b/.changeset/modern-poems-attack.md
@@ -1,0 +1,5 @@
+---
+'@crackle/router': minor
+---
+
+Update entrypoints

--- a/.changeset/unlucky-yaks-look.md
+++ b/.changeset/unlucky-yaks-look.md
@@ -1,0 +1,5 @@
+---
+'@crackle/cli': patch
+---
+
+Fix config overrides for `crackle serve`

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -70,7 +70,7 @@ yargs(process.argv.slice(2))
 
       const config = await resolveConfig({
         onUpdate: async (newConfig) => {
-          setConfigOverrides(config, overrides);
+          setConfigOverrides(newConfig, overrides);
 
           if (server) {
             logger.info('Updated config found. Restarting server...');
@@ -86,7 +86,7 @@ yargs(process.argv.slice(2))
       server = serve(config);
     },
   })
-  .command<Pick<CrackleConfig, 'fix'>>({
+  .command<Pick<CrackleConfig, 'fix' | 'clean'>>({
     command: 'package',
     describe: '#TODO',
     builder: {


### PR DESCRIPTION
- Fixed entrypoints for `@crackle/router`

  Forgot to add a changeset for `@crackle/router` in #27 and the currently published version fails in Gotham candidate (which is `type: module`):

  ```
  Render pages failed
  Error: Directory import '/__/project-gotham/sites/candidate/node_modules/@crackle/router/server' is
  not supported resolving ES modules imported from /__/project-gotham/sites/candidate/dist-render/build.js
  Did you mean to import @crackle+router@0.1.2_react-dom@17.0.2/node_modules/@crackle/router/server/dist/crackle-router-server.cjs.js?
  ```

- Fixed config overrides for `crackle serve`