### PR TITLE
Trim dependency graph scanner

### DIFF
--- a/.changeset/thin-coats-build.md
+++ b/.changeset/thin-coats-build.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': minor
+---
+
+Remove dependency graph scanner

--- a/.changeset/thin-coats-build.md
+++ b/.changeset/thin-coats-build.md
@@ -2,4 +2,4 @@
 '@crackle/core': minor
 ---
 
-Remove dependency graph scanner
+Remove `externals` logic from dependency graph scanner

--- a/fixtures/braid-site/package.json
+++ b/fixtures/braid-site/package.json
@@ -18,7 +18,7 @@
     "@crackle-fixtures/library-with-docs": "workspace:*",
     "@crackle/router": "workspace:*",
     "@vanilla-extract/css": "^1.9.2",
-    "braid-design-system": "0.0.0-crackel2-20221007054115",
+    "braid-design-system": "^32.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/fixtures/library-with-docs/package.json
+++ b/fixtures/library-with-docs/package.json
@@ -28,7 +28,7 @@
   "dependencies": {
     "@crackle/router": "workspace:*",
     "@vanilla-extract/css": "^1.9.2",
-    "braid-design-system": "0.0.0-crackel2-20221007054115",
+    "braid-design-system": "^32.0.0",
     "lodash": "^4.17.21",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"

--- a/fixtures/multi-entry-library/package.json
+++ b/fixtures/multi-entry-library/package.json
@@ -44,7 +44,7 @@
   },
   "dependencies": {
     "@crackle/router": "workspace:*",
-    "braid-design-system": "0.0.0-crackel2-20221007054115",
+    "braid-design-system": "^32.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/fixtures/single-entry-library/package.json
+++ b/fixtures/single-entry-library/package.json
@@ -27,7 +27,7 @@
   "dependencies": {
     "@crackle-fixtures/multi-entry-library": "workspace:*",
     "@vanilla-extract/css": "^1.9.2",
-    "braid-design-system": "0.0.0-crackel2-20221007054115",
+    "braid-design-system": "^32.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/fixtures/with-flatten-children/package.json
+++ b/fixtures/with-flatten-children/package.json
@@ -24,6 +24,7 @@
     "package": "crackle package"
   },
   "dependencies": {
+    "react": "^18.2.0",
     "react-keyed-flatten-children": "^1.3.0"
   },
   "devDpendencies": {}

--- a/package.json
+++ b/package.json
@@ -62,8 +62,16 @@
     ]
   },
   "pnpm": {
+    "neverBuiltDependencies": [
+      "sku"
+    ],
     "patchedDependencies": {
       "sync-dependencies@1.0.4": "patches/sync-dependencies@1.0.4.patch"
+    },
+    "peerDependencyRules": {
+      "ignoreMissing": [
+        "jest"
+      ]
     }
   }
 }

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -53,12 +53,7 @@ export const build = async (inlineConfig?: PartialConfig) => {
     ],
     logLevel: 'silent',
     ssr: {
-      external: [
-        'serialize-javascript',
-        'used-styles',
-        ...builtinModules,
-        ...ssrExternals.external,
-      ],
+      external: [...builtinModules, 'serialize-javascript', 'used-styles'],
       noExternal: ssrExternals.noExternal,
     },
   };

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -1,7 +1,7 @@
 import fs from 'fs/promises';
 import path from 'path';
 
-import { setAdapter } from '@vanilla-extract/css/adapter';
+import { mockAdapter, setAdapter } from '@vanilla-extract/css/adapter';
 import { vanillaExtractPlugin } from '@vanilla-extract/vite-plugin';
 import react from '@vitejs/plugin-react';
 import builtinModules from 'builtin-modules';
@@ -103,14 +103,7 @@ export const build = async (inlineConfig?: PartialConfig) => {
 
     logger.info(`✅ Successfully built ${chalk.bold('renderer')}!`);
 
-    setAdapter({
-      appendCss: () => {},
-      registerClassName: () => {},
-      onEndFileScope: () => {},
-      registerComposition: () => {},
-      markCompositionUsed: () => {},
-      getIdentOption: () => 'short',
-    });
+    setAdapter(mockAdapter);
 
     // TODO: use vite-node instead
     const { renderAllPages } = (await import(

--- a/packages/core/src/plugins/vite/page-roots.ts
+++ b/packages/core/src/plugins/vite/page-roots.ts
@@ -3,8 +3,7 @@ import path from 'path';
 import type { Plugin } from 'vite';
 
 import type { EnhancedConfig } from '../../config';
-
-const pageGlobSuffix = '/**/*.page.tsx';
+import { pageGlobSuffix } from '../../route-data';
 
 const browserPageModules = '__BROWSER_PAGE_MODULES';
 const nodePageModules = '__NODE_PAGE_MODULES';

--- a/packages/core/src/plugins/vite/strip-route-data.ts
+++ b/packages/core/src/plugins/vite/strip-route-data.ts
@@ -9,14 +9,15 @@ export const stripRouteData = (): Plugin => ({
       return;
     }
 
+    // TODO: merge with src/route-data.ts
     const transformedContents = await babelTransform(code, {
       plugins: [
         [
-          '@crackle/babel-plugin-remove-exports',
+          require.resolve('@crackle/babel-plugin-remove-exports'),
           { retainDefault: true, retainIdentifiers: ['React'] },
         ],
-        '@babel/plugin-syntax-jsx',
-        ['@babel/plugin-syntax-typescript', { isTSX: true }],
+        require.resolve('@babel/plugin-syntax-jsx'),
+        [require.resolve('@babel/plugin-syntax-typescript'), { isTSX: true }],
       ],
       babelrc: false,
       configFile: false,

--- a/packages/core/src/route-data.ts
+++ b/packages/core/src/route-data.ts
@@ -15,14 +15,15 @@ const routesEntryName = 'ROUTES_ENTRY';
 const routeEntryNs = 'ROUTES_ENTRY_NAMESPACE';
 
 const transformWithBabel = async (file: string) => {
+  // TODO: merge with src/plugins/vite/strip-route-data.ts
   const transformedContents = await babelTransform(file, {
     plugins: [
       [
-        '@crackle/babel-plugin-remove-exports',
+        require.resolve('@crackle/babel-plugin-remove-exports'),
         { retainExports: ['routeData'] },
       ],
-      '@babel/plugin-syntax-jsx',
-      ['@babel/plugin-syntax-typescript', { isTSX: true }],
+      require.resolve('@babel/plugin-syntax-jsx'),
+      [require.resolve('@babel/plugin-syntax-typescript'), { isTSX: true }],
     ],
     babelrc: false,
     configFile: false,

--- a/packages/core/src/start.ts
+++ b/packages/core/src/start.ts
@@ -83,6 +83,7 @@ export const start = async (
       external: [
         ...builtinModules,
         '@crackle/router',
+        '@vanilla-extract/css/adapter',
         'serialize-javascript',
         'used-styles',
       ],

--- a/packages/core/src/start.ts
+++ b/packages/core/src/start.ts
@@ -36,14 +36,13 @@ export const start = async (
   inlineConfig?: PartialConfig,
 ): Promise<CrackleServer> => {
   const config = getConfig(inlineConfig);
-  const app = express();
-
   const depGraph = await extractDependencyGraph(config.root);
   const ssrExternals = getSsrExternalsForCompiledDependency(
     '@vanilla-extract/css',
     depGraph,
   );
 
+  const app = express();
   const connections = new Map<string, Socket>();
 
   const vite = await createViteServer({
@@ -81,17 +80,15 @@ export const start = async (
     },
     ssr: {
       external: [
+        ...builtinModules,
         '@crackle/router',
         'serialize-javascript',
         'used-styles',
-        '@vanilla-extract/css/transformCss',
-        '@vanilla-extract/css/adapter',
-        ...builtinModules,
-        ...ssrExternals.external,
       ],
       noExternal: ssrExternals.noExternal,
     },
   });
+
   // use vite's connect instance as middleware
   app.use(vite.middlewares);
 

--- a/packages/core/src/start.ts
+++ b/packages/core/src/start.ts
@@ -20,6 +20,7 @@ import {
   internalPackageResolution,
   stripRouteData,
 } from './plugins/vite';
+import { pageGlobSuffix } from './route-data';
 import type { CrackleServer } from './types';
 import {
   extractDependencyGraph,
@@ -65,7 +66,7 @@ export const start = async (
     optimizeDeps: {
       entries: [
         ...config.pageRoots.map((pageRoot) =>
-          path.join(pageRoot, '/**/*.page.tsx'),
+          path.join(pageRoot, pageGlobSuffix),
         ),
         config.appShell,
       ],

--- a/patches/sync-dependencies@1.0.4.patch
+++ b/patches/sync-dependencies@1.0.4.patch
@@ -7,7 +7,7 @@ index 4e8bcce0d140d30720fe52896b5987f04253d25c..e10a320e7d55b9cd7eee0e4358c109b9
      for (var dependency in dependencies) {
          if (dependencies.hasOwnProperty(dependency)) {
 -            var version = targetJson.dependencies[dependency] || targetJson.devDependencies[dependency];
-+            var version = (targetJson.dependencies || {})[dependency] || (targetJson.devDependencies || {})[dependency];
++            var version = targetJson.dependencies?.[dependency] || targetJson.devDependencies?.[dependency];
              if (version && version !== dependencies[dependency]) {
                  console.log('Updating ' + dependency + ' from ' + dependencies[dependency] + ' to ' + version + '.');
                  dependencies[dependency] = version;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,8 +1,11 @@
 lockfileVersion: 5.4
 
+neverBuiltDependencies:
+  - sku
+
 patchedDependencies:
   sync-dependencies@1.0.4:
-    hash: kmihzdv5wva4zagwidt2n34234
+    hash: kz43vugpxzze664l527a72jrc4
     path: patches/sync-dependencies@1.0.4.patch
 
 importers:
@@ -62,14 +65,14 @@ importers:
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
       '@vanilla-extract/css': ^1.9.2
-      braid-design-system: 0.0.0-crackel2-20221007054115
+      braid-design-system: ^32.0.0
       react: ^18.2.0
       react-dom: ^18.2.0
     dependencies:
       '@crackle-fixtures/library-with-docs': link:../library-with-docs
       '@crackle/router': link:../../packages/router
-      '@vanilla-extract/css': 1.9.2
-      braid-design-system: 0.0.0-crackel2-20221007054115_2zx2umvpluuhvlq44va5bta2da
+      '@vanilla-extract/css': 1.9.5
+      braid-design-system: 32.0.0_2zx2umvpluuhvlq44va5bta2da
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
@@ -108,14 +111,14 @@ importers:
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
       '@vanilla-extract/css': ^1.9.2
-      braid-design-system: 0.0.0-crackel2-20221007054115
+      braid-design-system: ^32.0.0
       lodash: ^4.17.21
       react: ^18.2.0
       react-dom: ^18.2.0
     dependencies:
       '@crackle/router': link:../../packages/router
-      '@vanilla-extract/css': 1.9.2
-      braid-design-system: 0.0.0-crackel2-20221007054115_2zx2umvpluuhvlq44va5bta2da
+      '@vanilla-extract/css': 1.9.5
+      braid-design-system: 32.0.0_2zx2umvpluuhvlq44va5bta2da
       lodash: 4.17.21
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
@@ -133,12 +136,12 @@ importers:
       '@crackle/router': workspace:*
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
-      braid-design-system: 0.0.0-crackel2-20221007054115
+      braid-design-system: ^32.0.0
       react: ^18.2.0
       react-dom: ^18.2.0
     dependencies:
       '@crackle/router': link:../../packages/router
-      braid-design-system: 0.0.0-crackel2-20221007054115_2zx2umvpluuhvlq44va5bta2da
+      braid-design-system: 32.0.0_2zx2umvpluuhvlq44va5bta2da
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
@@ -155,13 +158,13 @@ importers:
       '@types/react': ^18.0.21
       '@types/react-dom': ^18.0.6
       '@vanilla-extract/css': ^1.9.2
-      braid-design-system: 0.0.0-crackel2-20221007054115
+      braid-design-system: ^32.0.0
       react: ^18.2.0
       react-dom: ^18.2.0
     dependencies:
       '@crackle-fixtures/multi-entry-library': link:../multi-entry-library
-      '@vanilla-extract/css': 1.9.2
-      braid-design-system: 0.0.0-crackel2-20221007054115_2zx2umvpluuhvlq44va5bta2da
+      '@vanilla-extract/css': 1.9.5
+      braid-design-system: 32.0.0_2zx2umvpluuhvlq44va5bta2da
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
     devDependencies:
@@ -178,17 +181,19 @@ importers:
 
   fixtures/with-flatten-children:
     specifiers:
+      react: ^18.2.0
       react-keyed-flatten-children: ^1.3.0
     dependencies:
-      react-keyed-flatten-children: 1.3.0
+      react: 18.2.0
+      react-keyed-flatten-children: 1.3.0_react@18.2.0
 
   fixtures/with-side-effects:
     specifiers:
       '@vanilla-extract/css': ^1.9.2
       '@vanilla-extract/sprinkles': ^1.5.1
     dependencies:
-      '@vanilla-extract/css': 1.9.2
-      '@vanilla-extract/sprinkles': 1.5.1_@vanilla-extract+css@1.9.2
+      '@vanilla-extract/css': 1.9.5
+      '@vanilla-extract/sprinkles': 1.5.1_@vanilla-extract+css@1.9.5
 
   packages/babel-plugin-remove-exports:
     specifiers:
@@ -207,7 +212,7 @@ importers:
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.12
       '@types/babel-plugin-tester': 9.0.5
-      '@types/babel__core': 7.1.20
+      '@types/babel__core': 7.20.0
       '@types/babel__traverse': 7.18.2
       babel-plugin-tester: 10.1.0_@babel+core@7.20.12
 
@@ -282,7 +287,7 @@ importers:
       '@crackle/babel-plugin-remove-exports': link:../babel-plugin-remove-exports
       '@crackle/router': link:../router
       '@ungap/structured-clone': 1.0.1
-      '@vanilla-extract/css': 1.9.2
+      '@vanilla-extract/css': 1.9.5
       '@vanilla-extract/integration': 6.0.1
       '@vanilla-extract/vite-plugin': 3.7.0_vite@4.1.1
       '@vitejs/plugin-react': 3.0.0_vite@4.1.1
@@ -313,7 +318,7 @@ importers:
       used-styles: 2.4.1
       vite: 4.1.1_@types+node@18.13.0
     devDependencies:
-      '@types/babel__core': 7.1.20
+      '@types/babel__core': 7.20.0
       '@types/express': 4.17.14
       '@types/fs-extra': 9.0.13
       '@types/glob-to-regexp': 0.4.1
@@ -326,7 +331,7 @@ importers:
       ink-testing-library: 2.1.0_@types+react@18.0.25
       memfs: 3.4.11
       strip-ansi: 7.0.1
-      sync-dependencies: 1.0.4_kmihzdv5wva4zagwidt2n34234
+      sync-dependencies: 1.0.4_kz43vugpxzze664l527a72jrc4
       typescript: 4.9.4
 
   packages/router:
@@ -360,7 +365,7 @@ importers:
     dependencies:
       '@crackle/core': link:../packages/core
       '@playwright/test': 1.22.2
-      sync-dependencies: 1.0.4_kmihzdv5wva4zagwidt2n34234
+      sync-dependencies: 1.0.4_kz43vugpxzze664l527a72jrc4
 
 packages:
 
@@ -369,7 +374,7 @@ packages:
     engines: {node: '>=6.0.0'}
     dependencies:
       '@jridgewell/gen-mapping': 0.1.1
-      '@jridgewell/trace-mapping': 0.3.16
+      '@jridgewell/trace-mapping': 0.3.17
 
   /@babel/code-frame/7.18.6:
     resolution: {integrity: sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==}
@@ -394,7 +399,7 @@ packages:
       '@babel/parser': 7.20.7
       '@babel/template': 7.20.7
       '@babel/traverse': 7.20.12
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
       convert-source-map: 1.9.0
       debug: 4.3.4
       gensync: 1.0.0-beta.2
@@ -421,7 +426,7 @@ packages:
     resolution: {integrity: sha512-7wqMOJq8doJMZmP4ApXTzLxSr7+oO2jroJURrVEp6XShrQUObV8Tq/D0NCcoYg2uHqUrjzO0zwBjoYzelxK+sw==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
       '@jridgewell/gen-mapping': 0.3.2
       jsesc: 2.5.2
 
@@ -429,7 +434,7 @@ packages:
     resolution: {integrity: sha512-duORpUiYrEpzKIop6iNbjnwKLAKnJ47csTyRACyEmWj0QdUrm5aqNJGHSSEQSUAvNW0ojX0dOmK9dZduvkfeXA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     dev: false
 
   /@babel/helper-builder-binary-assignment-operator-visitor/7.18.9:
@@ -437,7 +442,7 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-explode-assignable-expression': 7.18.6
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     dev: false
 
   /@babel/helper-compilation-targets/7.20.7_@babel+core@7.20.12:
@@ -453,8 +458,8 @@ packages:
       lru-cache: 5.1.1
       semver: 6.3.0
 
-  /@babel/helper-create-class-features-plugin/7.19.0_@babel+core@7.20.12:
-    resolution: {integrity: sha512-NRz8DwF4jT3UfrmUoZjd0Uph9HQnP30t7Ash+weACcyNkiYTywpIjDBgReJMKgr+n86sn2nPVVmJ28Dm053Kqw==}
+  /@babel/helper-create-class-features-plugin/7.21.0_@babel+core@7.20.12:
+    resolution: {integrity: sha512-Q8wNiMIdwsv5la5SPxNYzzkPnjgC0Sy0i7jLkVOCdllu/xcVNkr3TeZzbHBJrj+XXRqzX5uCyCoV9eu6xUG7KQ==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0
@@ -462,10 +467,11 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
-      '@babel/helper-member-expression-to-functions': 7.18.9
+      '@babel/helper-function-name': 7.21.0
+      '@babel/helper-member-expression-to-functions': 7.21.0
       '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/helper-replace-supers': 7.18.9
+      '@babel/helper-replace-supers': 7.20.7
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
       '@babel/helper-split-export-declaration': 7.18.6
     transitivePeerDependencies:
       - supports-color
@@ -506,34 +512,34 @@ packages:
     resolution: {integrity: sha512-eyAYAsQmB80jNfg4baAtLeWAQHfHFiR483rzFK+BhETlGZaQC9bsfrugfXDCbRHLQbIA7U5NxhhOxN7p/dWIcg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     dev: false
 
-  /@babel/helper-function-name/7.19.0:
-    resolution: {integrity: sha512-WAwHBINyrpqywkUH0nTnNgI5ina5TFn85HKS0pbPDfxFfhyR/aNQEn4hGi1P1JyT//I0t4OgXUlofzWILRvS5w==}
+  /@babel/helper-function-name/7.21.0:
+    resolution: {integrity: sha512-HfK1aMRanKHpxemaY2gqBmL04iAPOPRj7DxtNbiDOrJK+gdwkiNRVpCpUJYbUT+aZyemKN8brqTOxzCaG6ExRg==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/template': 7.20.7
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@babel/helper-hoist-variables/7.18.6:
     resolution: {integrity: sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
-  /@babel/helper-member-expression-to-functions/7.18.9:
-    resolution: {integrity: sha512-RxifAh2ZoVU67PyKIO4AMi1wTenGfMR/O/ae0CCRqwgBAt5v7xjdtRw7UoSbsreKrQn5t7r89eruK/9JjYHuDg==}
+  /@babel/helper-member-expression-to-functions/7.21.0:
+    resolution: {integrity: sha512-Muu8cdZwNN6mRRNG6lAYErJ5X3bRevgYR2O8wN0yn7jJSnGDu6eG59RfT29JHxGUovyfrh6Pj0XzmR7drNVL3Q==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     dev: false
 
   /@babel/helper-module-imports/7.18.6:
     resolution: {integrity: sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@babel/helper-module-transforms/7.20.11:
     resolution: {integrity: sha512-uRy78kN4psmji1s2QtbtcCSaj/LILFDp0f/ymhpQH5QY3nljUZCaNWz9X1dEj/8MBdBEFECs7yRhKn8i7NjZgg==}
@@ -546,7 +552,7 @@ packages:
       '@babel/helper-validator-identifier': 7.19.1
       '@babel/template': 7.20.7
       '@babel/traverse': 7.20.12
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     transitivePeerDependencies:
       - supports-color
 
@@ -554,7 +560,7 @@ packages:
     resolution: {integrity: sha512-HP59oD9/fEHQkdcbgFCnbmgH5vIQTJbxh2yf+CdM89/glUNnuzr87Q8GIjGEnOktTROemO0Pe0iPAYbqZuOUiA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     dev: false
 
   /@babel/helper-plugin-utils/7.20.2:
@@ -571,7 +577,7 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.19.0
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -581,10 +587,24 @@ packages:
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-member-expression-to-functions': 7.18.9
+      '@babel/helper-member-expression-to-functions': 7.21.0
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/traverse': 7.20.12
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
+    transitivePeerDependencies:
+      - supports-color
+    dev: false
+
+  /@babel/helper-replace-supers/7.20.7:
+    resolution: {integrity: sha512-vujDMtB6LVfNW13jhlCrp48QNslK6JXi7lQG736HVbHz/mbf4Dc7tIRh1Xf5C0rF7BP8iiSxGMCmY6Ci1ven3A==}
+    engines: {node: '>=6.9.0'}
+    dependencies:
+      '@babel/helper-environment-visitor': 7.18.9
+      '@babel/helper-member-expression-to-functions': 7.21.0
+      '@babel/helper-optimise-call-expression': 7.18.6
+      '@babel/template': 7.20.7
+      '@babel/traverse': 7.20.12
+      '@babel/types': 7.21.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -593,20 +613,20 @@ packages:
     resolution: {integrity: sha512-+0woI/WPq59IrqDYbVGfshjT5Dmk/nnbdpcF8SnMhhXObpTq2KNBdLFRFrkVdbDOyUmHBCxzm5FHV1rACIkIbA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
-  /@babel/helper-skip-transparent-expression-wrappers/7.18.9:
-    resolution: {integrity: sha512-imytd2gHi3cJPsybLRbmFrF7u5BIEuI2cNheyKi3/iOBC63kNn3q8Crn2xVuESli0aM4KYsyEqKyS7lFL8YVtw==}
+  /@babel/helper-skip-transparent-expression-wrappers/7.20.0:
+    resolution: {integrity: sha512-5y1JYeNKfvnT8sZcK9DVRtpTbGiomYIHviSP3OQWmDPU3DeH4a1ZlT/N2lyQ5P8egjcRaT/Y9aNqUxK0WsnIIg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     dev: false
 
   /@babel/helper-split-export-declaration/7.18.6:
     resolution: {integrity: sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@babel/helper-string-parser/7.19.4:
     resolution: {integrity: sha512-nHtDoQcuqFmwYNYPz3Rah5ph2p8PFeFCsZk9A/48dPc/rGocJ5J3hAAZ7pb76VWX3fZKu+uEr/FhH5jLx7umrw==}
@@ -624,10 +644,10 @@ packages:
     resolution: {integrity: sha512-txX8aN8CZyYGTwcLhlk87KRqncAzhh5TpQamZUa0/u3an36NtDpUP6bQgBCBcLeBs09R/OwQu3OjK0k/HwfNDg==}
     engines: {node: '>=6.9.0'}
     dependencies:
-      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-function-name': 7.21.0
       '@babel/template': 7.20.7
       '@babel/traverse': 7.20.12
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -638,7 +658,7 @@ packages:
     dependencies:
       '@babel/template': 7.20.7
       '@babel/traverse': 7.20.12
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     transitivePeerDependencies:
       - supports-color
 
@@ -655,7 +675,7 @@ packages:
     engines: {node: '>=6.0.0'}
     hasBin: true
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression/7.18.6_@babel+core@7.20.12:
     resolution: {integrity: sha512-Dgxsyg54Fx1d4Nge8UnvTrED63vrwOdPmyvPzlNN/boaliRP54pm3pGzZD1SJUwrBA+Cs/xdG8kXX6Mn/RfISQ==}
@@ -675,7 +695,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
       '@babel/plugin-proposal-optional-chaining': 7.18.9_@babel+core@7.20.12
     dev: false
 
@@ -701,7 +721,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.20.12
+      '@babel/helper-create-class-features-plugin': 7.21.0_@babel+core@7.20.12
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -714,7 +734,7 @@ packages:
       '@babel/core': ^7.12.0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.20.12
+      '@babel/helper-create-class-features-plugin': 7.21.0_@babel+core@7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-class-static-block': 7.14.5_@babel+core@7.20.12
     transitivePeerDependencies:
@@ -820,7 +840,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
       '@babel/plugin-syntax-optional-chaining': 7.8.3_@babel+core@7.20.12
     dev: false
 
@@ -831,7 +851,7 @@ packages:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.20.12
+      '@babel/helper-create-class-features-plugin': 7.21.0_@babel+core@7.20.12
       '@babel/helper-plugin-utils': 7.20.2
     transitivePeerDependencies:
       - supports-color
@@ -845,7 +865,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-annotate-as-pure': 7.18.6
-      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.20.12
+      '@babel/helper-create-class-features-plugin': 7.21.0_@babel+core@7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-private-property-in-object': 7.14.5_@babel+core@7.20.12
     transitivePeerDependencies:
@@ -1092,10 +1112,10 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-function-name': 7.21.0
       '@babel/helper-optimise-call-expression': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-replace-supers': 7.18.9
+      '@babel/helper-replace-supers': 7.20.7
       '@babel/helper-split-export-declaration': 7.18.6
       globals: 11.12.0
     transitivePeerDependencies:
@@ -1172,7 +1192,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-compilation-targets': 7.20.7_@babel+core@7.20.12
-      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-function-name': 7.21.0
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
@@ -1359,7 +1379,7 @@ packages:
       '@babel/helper-module-imports': 7.18.6
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.12
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     dev: false
 
   /@babel/plugin-transform-react-pure-annotations/7.18.6_@babel+core@7.20.12:
@@ -1412,7 +1432,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-skip-transparent-expression-wrappers': 7.18.9
+      '@babel/helper-skip-transparent-expression-wrappers': 7.20.0
     dev: false
 
   /@babel/plugin-transform-sticky-regex/7.18.6_@babel+core@7.20.12:
@@ -1445,14 +1465,14 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
     dev: false
 
-  /@babel/plugin-transform-typescript/7.19.0_@babel+core@7.20.12:
-    resolution: {integrity: sha512-DOOIywxPpkQHXijXv+s9MDAyZcLp12oYRl3CMWZ6u7TjSoCBq/KqHR/nNFR3+i2xqheZxoF0H2XyL7B6xeSRuA==}
+  /@babel/plugin-transform-typescript/7.21.0_@babel+core@7.20.12:
+    resolution: {integrity: sha512-xo///XTPp3mDzTtrqXoBlK9eiAYW3wv9JXglcn/u1bi60RW11dEUxIgA8cbnDhutS1zacjMRmAwxE0gMklLnZg==}
     engines: {node: '>=6.9.0'}
     peerDependencies:
       '@babel/core': ^7.0.0-0
     dependencies:
       '@babel/core': 7.20.12
-      '@babel/helper-create-class-features-plugin': 7.19.0_@babel+core@7.20.12
+      '@babel/helper-create-class-features-plugin': 7.21.0_@babel+core@7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.12
     transitivePeerDependencies:
@@ -1556,7 +1576,7 @@ packages:
       '@babel/plugin-transform-unicode-escapes': 7.18.10_@babel+core@7.20.12
       '@babel/plugin-transform-unicode-regex': 7.18.6_@babel+core@7.20.12
       '@babel/preset-modules': 0.1.5_@babel+core@7.20.12
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
       babel-plugin-polyfill-corejs2: 0.3.3_@babel+core@7.20.12
       babel-plugin-polyfill-corejs3: 0.6.0_@babel+core@7.20.12
       babel-plugin-polyfill-regenerator: 0.4.1_@babel+core@7.20.12
@@ -1575,7 +1595,7 @@ packages:
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/plugin-proposal-unicode-property-regex': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-transform-dotall-regex': 7.18.6_@babel+core@7.20.12
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
       esutils: 2.0.3
     dev: false
 
@@ -1603,7 +1623,7 @@ packages:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
       '@babel/helper-validator-option': 7.18.6
-      '@babel/plugin-transform-typescript': 7.19.0_@babel+core@7.20.12
+      '@babel/plugin-transform-typescript': 7.21.0_@babel+core@7.20.12
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -1621,7 +1641,7 @@ packages:
     dependencies:
       '@babel/code-frame': 7.18.6
       '@babel/parser': 7.20.7
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@babel/traverse/7.20.12:
     resolution: {integrity: sha512-MsIbFN0u+raeja38qboyF8TIT7K0BFzz/Yd/77ta4MsUsmP2RAnidIlwq7d5HFQrH/OZJecGV6B71C4zAgpoSQ==}
@@ -1630,18 +1650,18 @@ packages:
       '@babel/code-frame': 7.18.6
       '@babel/generator': 7.20.7
       '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-function-name': 7.19.0
+      '@babel/helper-function-name': 7.21.0
       '@babel/helper-hoist-variables': 7.18.6
       '@babel/helper-split-export-declaration': 7.18.6
       '@babel/parser': 7.20.7
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
       debug: 4.3.4
       globals: 11.12.0
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/types/7.20.7:
-    resolution: {integrity: sha512-69OnhBxSSgK0OzTJai4kyPDiKTIe3j+ctaHdIGVbRahTLAT7L3R9oeXHC2aVSuGYt3cVnoAMDmOCgJ2yaiLMvg==}
+  /@babel/types/7.21.2:
+    resolution: {integrity: sha512-3wRZSs7jiFaB8AjxiiD+VqN5DTG2iRvJGQ+qYFrs/654lg6kGTQWIOFjlBo5RaXuAZjBmP3+OQH4dmhqiiyYxw==}
     engines: {node: '>=6.9.0'}
     dependencies:
       '@babel/helper-string-parser': 7.19.4
@@ -1652,13 +1672,13 @@ packages:
     resolution: {integrity: sha512-tJNEWMmhHcU5z6ITAiVNN9z+PCTylybVIJqgX7Ts4zN66fe/W2Fe5UWJCCZIP/5uutsl5fYOaVVHZIjsuTVhBQ==}
     dev: false
 
-  /@capsizecss/vanilla-extract/1.0.0_@vanilla-extract+css@1.9.2:
+  /@capsizecss/vanilla-extract/1.0.0_@vanilla-extract+css@1.9.5:
     resolution: {integrity: sha512-/cY34CgCAmuf6SmpgPXmDJaIdJOaRe37MsoeZIeZme4k0F0HFts+poTxq4m8UtBH7LRxpUkfUHDoRO9OYjjVBg==}
     peerDependencies:
       '@vanilla-extract/css': ^1.2.1
     dependencies:
       '@capsizecss/core': 3.0.0
-      '@vanilla-extract/css': 1.9.2
+      '@vanilla-extract/css': 1.9.5
     dev: false
 
   /@changesets/apply-release-plan/6.1.1:
@@ -1861,101 +1881,6 @@ packages:
       fs-extra: 7.0.1
       human-id: 1.0.2
       prettier: 2.8.2
-    dev: false
-
-  /@crackle/babel-plugin-remove-exports/0.1.0:
-    resolution: {integrity: sha512-q1NeAjq1ud/DLJq75sMSOsHMtvfXglQ1ki2yWjRlJgI1Zwe6l3tEA9QRZs7rq0UWrZmL/esynGqreJFGdWgZ8A==}
-    dependencies:
-      '@babel/core': 7.20.12
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@crackle/cli/0.9.1_@types+react@18.0.25:
-    resolution: {integrity: sha512-JoO8Cswpc5sQiVW2Tdlhd+D3TuQ3QQ/LTrAXd5UiAc+CSTid0BHXHAH31+FnBPDYNpufsG7Q18t3EQkEaCNQaQ==}
-    hasBin: true
-    dependencies:
-      '@crackle/core': 0.12.1_@types+react@18.0.25
-      yargs: 17.6.2
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@types/react'
-      - bufferutil
-      - less
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - ts-node
-      - typescript
-      - utf-8-validate
-    dev: false
-
-  /@crackle/core/0.12.1_@types+react@18.0.25:
-    resolution: {integrity: sha512-gXqXcM16v9f1sakdmL9/lnz/xZjE3dmHJgYePm0XaRkQM8B0g5UQEu/h6rMOK3X5W1uIBbyS7lFHXCy49LMwBQ==}
-    peerDependencies:
-      typescript: ~4.7.4
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.12
-      '@crackle/babel-plugin-remove-exports': 0.1.0
-      '@crackle/router': 0.1.2_rucwy2ro6yyrjn73fut3quomqm
-      '@rollup/plugin-commonjs': 22.0.2_rollup@2.78.1
-      '@rollup/plugin-node-resolve': 13.3.0_rollup@2.78.1
-      '@vanilla-extract/css': 1.9.2
-      '@vanilla-extract/integration': 6.0.1
-      '@vanilla-extract/vite-plugin': 3.7.0_vite@3.2.5
-      '@vitejs/plugin-react': 2.2.0_vite@3.2.5
-      builtin-modules: 3.3.0
-      chalk: 4.1.2
-      ensure-gitignore: 1.2.0
-      esbuild: 0.16.17
-      eval: 0.1.8
-      express: 4.18.2
-      fast-glob: 3.2.12
-      fs-extra: 10.1.0
-      history: 5.3.0
-      ink: 3.2.0_qnxonbsml5syl42mqdnwkqq4yu
-      mlly: 0.5.16
-      normalize-path: 3.0.0
-      parse-json: 5.2.0
-      pretty-ms: 7.0.1
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      resolve-from: 5.0.0
-      rollup: 2.78.1
-      rollup-plugin-dts: 4.2.3_rollup@2.78.1
-      rollup-plugin-esbuild: 4.10.1_odgv4gppx6j6fbpqvrdtgyyify
-      rollup-plugin-node-externals: 4.1.1_rollup@2.78.1
-      serialize-javascript: 6.0.0
-      serve-handler: 6.1.5
-      sort-package-json: 1.57.0
-      used-styles: 2.4.1
-      vite: 3.2.5
-    transitivePeerDependencies:
-      - '@types/node'
-      - '@types/react'
-      - bufferutil
-      - less
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - ts-node
-      - utf-8-validate
-    dev: false
-
-  /@crackle/router/0.1.2_rucwy2ro6yyrjn73fut3quomqm:
-    resolution: {integrity: sha512-RaUcPiq1ZiXLA/tk5fdhXZJm+J83id2tQyusDx77O5zCcmR0VwXnr5dKioRd2ebM+XOBKDXp+dwJIcwuxbMpPQ==}
-    dependencies:
-      react: 17.0.2
-      react-router-dom: 6.0.0-beta.2_o2pg7ethq7rrtlls7f3e52nciu
-    transitivePeerDependencies:
-      - history
-      - react-dom
     dev: false
 
   /@emotion/hash/0.9.0:
@@ -2272,7 +2197,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@jest/types': 29.0.2
-      '@jridgewell/trace-mapping': 0.3.16
+      '@jridgewell/trace-mapping': 0.3.17
       babel-plugin-istanbul: 6.1.1
       chalk: 4.1.2
       convert-source-map: 1.9.0
@@ -2314,7 +2239,7 @@ packages:
     dependencies:
       '@jridgewell/set-array': 1.1.2
       '@jridgewell/sourcemap-codec': 1.4.14
-      '@jridgewell/trace-mapping': 0.3.16
+      '@jridgewell/trace-mapping': 0.3.17
 
   /@jridgewell/resolve-uri/3.1.0:
     resolution: {integrity: sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==}
@@ -2328,14 +2253,14 @@ packages:
     resolution: {integrity: sha512-m7O9o2uR8k2ObDysZYzdfhb08VuEml5oWGiosa1VdaPZ/A6QyPkAJuwN0Q1lhULOf6B7MtQmHENS743hWtCrgw==}
     dependencies:
       '@jridgewell/gen-mapping': 0.3.2
-      '@jridgewell/trace-mapping': 0.3.16
+      '@jridgewell/trace-mapping': 0.3.17
     dev: false
 
   /@jridgewell/sourcemap-codec/1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
 
-  /@jridgewell/trace-mapping/0.3.16:
-    resolution: {integrity: sha512-LCQ+NeThyJ4k1W2d+vIKdxuSt9R3pQSZ4P92m7EakaYuXcVWbHuT5bjNcqLd4Rdgi6xYWYDvBJZJLZSLanjDcA==}
+  /@jridgewell/trace-mapping/0.3.17:
+    resolution: {integrity: sha512-MCNzAp77qzKca9+W/+I0+sEpaUnZoeasnghNeVc41VZCEKaCH73Vq3BZZ/SzWIgrqE4H4ceI+p+b6C0mHf9T4g==}
     dependencies:
       '@jridgewell/resolve-uri': 3.1.0
       '@jridgewell/sourcemap-codec': 1.4.14
@@ -2512,22 +2437,6 @@ packages:
       rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-commonjs/22.0.2_rollup@2.78.1:
-    resolution: {integrity: sha512-//NdP6iIwPbMTcazYsiBMbJW7gfmpHom33u1beiIoHDEM0Q9clvtQB1T0efvMqHeKsGohiHo97BCPCkBXdscwg==}
-    engines: {node: '>= 12.0.0'}
-    peerDependencies:
-      rollup: ^2.68.0
-    dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.78.1
-      commondir: 1.0.1
-      estree-walker: 2.0.2
-      glob: 7.2.3
-      is-reference: 1.2.1
-      magic-string: 0.25.9
-      resolve: 1.22.1
-      rollup: 2.78.1
-    dev: false
-
   /@rollup/plugin-json/4.1.0_rollup@2.79.1:
     resolution: {integrity: sha512-yfLbTdNS6amI/2OpmbiBoW12vngr5NW2jCJVZSBEz+H5KfUJZ2M7sDjk0U6GOOdCWFVScShte29o9NezJ53TPw==}
     peerDependencies:
@@ -2552,21 +2461,6 @@ packages:
       rollup: 2.79.1
     dev: false
 
-  /@rollup/plugin-node-resolve/13.3.0_rollup@2.78.1:
-    resolution: {integrity: sha512-Lus8rbUo1eEcnS4yTFKLZrVumLPY+YayBdWXgFSHYhTT2iJbMhoaaBL3xl5NCdeRytErGr8tZ0L71BMRmnlwSw==}
-    engines: {node: '>= 10.0.0'}
-    peerDependencies:
-      rollup: ^2.42.0
-    dependencies:
-      '@rollup/pluginutils': 3.1.0_rollup@2.78.1
-      '@types/resolve': 1.17.1
-      deepmerge: 4.2.2
-      is-builtin-module: 3.2.0
-      is-module: 1.0.0
-      resolve: 1.22.1
-      rollup: 2.78.1
-    dev: false
-
   /@rollup/plugin-replace/2.4.2_rollup@2.79.1:
     resolution: {integrity: sha512-IGcu+cydlUMZ5En85jxHH4qj2hta/11BHq95iHEyb2sbgiN0eCdzvUcHw5gt9pBL5lTi4JDYJ1acCoMGpTvEZg==}
     peerDependencies:
@@ -2575,18 +2469,6 @@ packages:
       '@rollup/pluginutils': 3.1.0_rollup@2.79.1
       magic-string: 0.25.9
       rollup: 2.79.1
-    dev: false
-
-  /@rollup/pluginutils/3.1.0_rollup@2.78.1:
-    resolution: {integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==}
-    engines: {node: '>= 8.0.0'}
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0
-    dependencies:
-      '@types/estree': 0.0.39
-      estree-walker: 1.0.1
-      picomatch: 2.3.1
-      rollup: 2.78.1
     dev: false
 
   /@rollup/pluginutils/3.1.0_rollup@2.79.1:
@@ -2601,14 +2483,6 @@ packages:
       rollup: 2.79.1
     dev: false
 
-  /@rollup/pluginutils/4.2.1:
-    resolution: {integrity: sha512-iKnFXr7NkdZAIHiIWE+BX5ULi/ucVFYWD6TbAV+rZctiRTY2PL6tsIKhoIOaoskiWAkgu+VsbXgUVDNLHf+InQ==}
-    engines: {node: '>= 8.0.0'}
-    dependencies:
-      estree-walker: 2.0.2
-      picomatch: 2.3.1
-    dev: false
-
   /@sinclair/typebox/0.24.39:
     resolution: {integrity: sha512-GqtkxoAjhTzoMwFg/JYRl+1+miOoyvp6mkLpbMSd2fIQak2KvY00ndlXxxkDBpuCPYkorZeEZf0LEQn9V9NRVQ==}
     dev: false
@@ -2619,15 +2493,15 @@ packages:
   /@types/babel-plugin-tester/9.0.5:
     resolution: {integrity: sha512-NRBPlhi5VkrTXMqDB1hSUnHs7vqLGRopeukC9u1zilOIFe9O1siwqeKZRiuJiVYakgpeDso/HE2Q5DU1aDqBog==}
     dependencies:
-      '@types/babel__core': 7.1.20
+      '@types/babel__core': 7.20.0
       '@types/prettier': 2.7.0
     dev: true
 
-  /@types/babel__core/7.1.20:
-    resolution: {integrity: sha512-PVb6Bg2QuscZ30FvOU7z4guG6c926D9YRvOxEaelzndpMsvP+YM74Q/dAFASpg2l6+XLalxSGxcq/lrgYWZtyQ==}
+  /@types/babel__core/7.20.0:
+    resolution: {integrity: sha512-+n8dL/9GWblDO0iU6eZAwEIJVr5DWigtle+Q6HLOrh/pdbXOhOtqzq8VPPE2zvNJzSKY4vH/z3iT3tn0A3ypiQ==}
     dependencies:
       '@babel/parser': 7.20.7
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
       '@types/babel__generator': 7.6.4
       '@types/babel__template': 7.4.1
       '@types/babel__traverse': 7.18.2
@@ -2636,20 +2510,20 @@ packages:
   /@types/babel__generator/7.6.4:
     resolution: {integrity: sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     dev: true
 
   /@types/babel__template/7.4.1:
     resolution: {integrity: sha512-azBFKemX6kMg5Io+/rdGT0dkGreboUVR0Cdm3fz9QJWpaQGJRQXl7C+6hOTCZcMll7KFyEQpgbYI2lHdsS4U7g==}
     dependencies:
       '@babel/parser': 7.20.7
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
     dev: true
 
   /@types/babel__traverse/7.18.2:
     resolution: {integrity: sha512-FcFaxOr2V5KZCviw1TnutEMVUVsGt4D2hP1TAfXZAMKuHYW3xQhe3jTxNPWutgCJ3/X1c5yX8ZoGVEItxKbwBg==}
     dependencies:
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
 
   /@types/body-parser/1.19.2:
     resolution: {integrity: sha512-ALYone6pm6QmwZoAgeyNksccT9Q4AWZQ6PvfwR37GT6r6FWUPguq6sUmNGSMV2Wr761oQoBxwGGa6DR5o1DC9g==}
@@ -3076,8 +2950,8 @@ packages:
     resolution: {integrity: sha512-PZAcHROlgtCUGI2y0JntdNwvPwCNyeVnkQu6KTYKdmxBbK3w72XJUmLFYapfaFfgami4I9CTLnrJTPdtmS3gpw==}
     dev: false
 
-  /@vanilla-extract/css/1.9.2:
-    resolution: {integrity: sha512-CE5+R89LOl9XG5dRwEIvVyl/YcS2GkqjdE/XnGJ+p7Fp6Exu08fifv7tY87XxFeCIRAbc9psM+h4lF+wC3Y0fg==}
+  /@vanilla-extract/css/1.9.5:
+    resolution: {integrity: sha512-aVSv6q24zelKRtWx/l9yshU3gD1uCDMZ2ZGcIiYnAcPfyLryrG/1X5DxtyiPKcyI/hZWoteHofsN//2q9MvzOA==}
     dependencies:
       '@emotion/hash': 0.9.0
       '@vanilla-extract/private': 1.0.3
@@ -3092,13 +2966,19 @@ packages:
       outdent: 0.8.0
     dev: false
 
+  /@vanilla-extract/dynamic/2.0.3:
+    resolution: {integrity: sha512-Rglfw2gXAYiBzAQ4jgUG7rBgE2c88e/zcG27ZVoIqMHVq56wf2C1katGMm1yFMNBgzqM7oBNYzz4YOMzznydkg==}
+    dependencies:
+      '@vanilla-extract/private': 1.0.3
+    dev: false
+
   /@vanilla-extract/integration/6.0.1:
     resolution: {integrity: sha512-8D2JdBTH6UEao5Tm50m1qtY63JP4hDxiv/sNvgj2+ix/9M5RML9sa0diS80u0hW/r26+/ZsdzoA5YIbg6ghOMw==}
     dependencies:
       '@babel/core': 7.20.12
       '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.12
       '@vanilla-extract/babel-plugin-debug-ids': 1.0.0
-      '@vanilla-extract/css': 1.9.2
+      '@vanilla-extract/css': 1.9.5
       esbuild: 0.11.23
       eval: 0.1.6
       find-up: 5.0.0
@@ -3113,27 +2993,12 @@ packages:
     resolution: {integrity: sha512-17kVyLq3ePTKOkveHxXuIJZtGYs+cSoev7BlP+Lf4916qfDhk/HBjvlYDe8egrea7LNPHKwSZJK/bzZC+Q6AwQ==}
     dev: false
 
-  /@vanilla-extract/sprinkles/1.5.1_@vanilla-extract+css@1.9.2:
+  /@vanilla-extract/sprinkles/1.5.1_@vanilla-extract+css@1.9.5:
     resolution: {integrity: sha512-xPYpeEZEC1mhiPqWCBPGdIHkpFaaQIbaAfG9W2JyIW0byqTP7CoaxdYNMPjhZuoV5lkTI14SJg8Bt+fZqmV5yQ==}
     peerDependencies:
       '@vanilla-extract/css': ^1.0.0
     dependencies:
-      '@vanilla-extract/css': 1.9.2
-    dev: false
-
-  /@vanilla-extract/vite-plugin/3.7.0_vite@3.2.5:
-    resolution: {integrity: sha512-Sq54d1f+Bww09e9Q5acFsNKjlSYMQ4GewJthdb3CVwUeGVzV10rJBChw6zufs7ndmJVCzQ4I2IcNMy2OiAlkmA==}
-    peerDependencies:
-      vite: ^2.2.3 || ^3.0.0
-    dependencies:
-      '@vanilla-extract/integration': 6.0.1
-      outdent: 0.8.0
-      postcss: 8.4.21
-      postcss-load-config: 3.1.4_postcss@8.4.21
-      vite: 3.2.5
-    transitivePeerDependencies:
-      - supports-color
-      - ts-node
+      '@vanilla-extract/css': 1.9.5
     dev: false
 
   /@vanilla-extract/vite-plugin/3.7.0_vite@4.1.1:
@@ -3149,24 +3014,6 @@ packages:
     transitivePeerDependencies:
       - supports-color
       - ts-node
-    dev: false
-
-  /@vitejs/plugin-react/2.2.0_vite@3.2.5:
-    resolution: {integrity: sha512-FFpefhvExd1toVRlokZgxgy2JtnBOdp4ZDsq7ldCWaqGSGn9UhWMAVm/1lxPL14JfNS5yGz+s9yFrQY6shoStA==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    peerDependencies:
-      vite: ^3.0.0
-    dependencies:
-      '@babel/core': 7.20.12
-      '@babel/plugin-transform-react-jsx': 7.19.0_@babel+core@7.20.12
-      '@babel/plugin-transform-react-jsx-development': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-react-jsx-self': 7.18.6_@babel+core@7.20.12
-      '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.20.12
-      magic-string: 0.26.7
-      react-refresh: 0.14.0
-      vite: 3.2.5
-    transitivePeerDependencies:
-      - supports-color
     dev: false
 
   /@vitejs/plugin-react/3.0.0_vite@4.1.1:
@@ -3588,23 +3435,23 @@ packages:
       fill-range: 7.0.1
     dev: false
 
-  /braid-design-system/0.0.0-crackel2-20221007054115_2zx2umvpluuhvlq44va5bta2da:
-    resolution: {integrity: sha512-71Zq0Y9tn/qRGcYF9V7iz2xHTioqqRBm0snvLrGnNfgrSy1ltbgCpjM0IyaahbOCg7OVMl+xFkev5BBEx+2qeA==}
+  /braid-design-system/32.0.0_2zx2umvpluuhvlq44va5bta2da:
+    resolution: {integrity: sha512-XkGPfWytY/Cm+vB9F/rt8mtv//JmTtSe3aeDzjIxr51zB4z5geCjPbU7UoDvrfuOCLGMqH2eObZOG3oeHgcs+w==}
     hasBin: true
     peerDependencies:
-      react: ^16.8.0 || ^17 || ^18
-      react-dom: ^16.8.0 || ^17 || ^18
+      react: ^17 || ^18
+      react-dom: ^17 || ^18
       sku: '>=10.13.1'
     dependencies:
       '@capsizecss/core': 3.0.0
-      '@capsizecss/vanilla-extract': 1.0.0_@vanilla-extract+css@1.9.2
-      '@crackle/cli': 0.9.1_@types+react@18.0.25
+      '@capsizecss/vanilla-extract': 1.0.0_@vanilla-extract+css@1.9.5
       '@types/autosuggest-highlight': 3.2.0
       '@types/dedent': 0.7.0
       '@types/lodash': 4.14.186
-      '@vanilla-extract/css': 1.9.2
+      '@vanilla-extract/css': 1.9.5
       '@vanilla-extract/css-utils': 0.1.3
-      '@vanilla-extract/sprinkles': 1.5.1_@vanilla-extract+css@1.9.2
+      '@vanilla-extract/dynamic': 2.0.3
+      '@vanilla-extract/sprinkles': 1.5.1_@vanilla-extract+css@1.9.5
       assert: 2.0.0
       autosuggest-highlight: 3.3.4
       clsx: 1.2.1
@@ -3617,23 +3464,13 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-focus-lock: 2.9.1_fan5qbzahqtxlm5dzefqlqx5ia
+      react-is: 18.2.0
       react-popper-tooltip: 4.4.2_biqbaboplfbrettd7655fr4n2y
       react-remove-scroll: 2.5.5_fan5qbzahqtxlm5dzefqlqx5ia
       utility-types: 3.10.0
       uuid: 8.3.2
     transitivePeerDependencies:
-      - '@types/node'
       - '@types/react'
-      - bufferutil
-      - less
-      - sass
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - ts-node
-      - typescript
-      - utf-8-validate
     dev: false
 
   /breakword/1.0.5:
@@ -3729,7 +3566,7 @@ packages:
       check-error: 1.0.2
       deep-eql: 4.1.3
       get-func-name: 2.0.0
-      loupe: 2.3.4
+      loupe: 2.3.6
       pathval: 1.1.1
       type-detect: 4.0.8
     dev: false
@@ -4263,10 +4100,6 @@ packages:
       typed-array-length: 1.0.4
       unbox-primitive: 1.0.2
       which-typed-array: 1.1.9
-    dev: false
-
-  /es-module-lexer/0.9.3:
-    resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
     dev: false
 
   /es-module-lexer/1.1.0:
@@ -5502,12 +5335,6 @@ packages:
       function-bind: 1.1.1
     dev: false
 
-  /history/5.3.0:
-    resolution: {integrity: sha512-ZqaKwjjrAYUYfLG+htGaIIZ4nioX2L70ZUMIFysS3xvBsSG4x/n1V6TXV3N8ZYNuFGlDirFg32T7B6WOUPDYcQ==}
-    dependencies:
-      '@babel/runtime': 7.19.4
-    dev: false
-
   /hosted-git-info/2.8.9:
     resolution: {integrity: sha512-mxIDAb9Lsm6DoOJ7xH+5+X4y1LU/4Hi50L9C5sIswK3JzULS4bwk1FvjdBgvYR4bzT4tuUQiC15FE2f5HbLvYw==}
 
@@ -5637,46 +5464,6 @@ packages:
       - utf-8-validate
     dev: false
 
-  /ink/3.2.0_qnxonbsml5syl42mqdnwkqq4yu:
-    resolution: {integrity: sha512-firNp1q3xxTzoItj/eOOSZQnYSlyrWks5llCTVX37nJ59K3eXbQ8PtzCguqo8YI19EELo5QxaKnJd4VxzhU8tg==}
-    engines: {node: '>=10'}
-    peerDependencies:
-      '@types/react': '>=16.8.0'
-      react: '>=16.8.0'
-    peerDependenciesMeta:
-      '@types/react':
-        optional: true
-    dependencies:
-      '@types/react': 18.0.25
-      ansi-escapes: 4.3.2
-      auto-bind: 4.0.0
-      chalk: 4.1.2
-      cli-boxes: 2.2.1
-      cli-cursor: 3.1.0
-      cli-truncate: 2.1.0
-      code-excerpt: 3.0.0
-      indent-string: 4.0.0
-      is-ci: 2.0.0
-      lodash: 4.17.21
-      patch-console: 1.0.0
-      react: 17.0.2
-      react-devtools-core: 4.25.0
-      react-reconciler: 0.26.2_react@17.0.2
-      scheduler: 0.20.2
-      signal-exit: 3.0.7
-      slice-ansi: 3.0.0
-      stack-utils: 2.0.5
-      string-width: 4.2.3
-      type-fest: 0.12.0
-      widest-line: 3.1.0
-      wrap-ansi: 6.2.0
-      ws: 7.5.9
-      yoga-layout-prebuilt: 1.10.0
-    transitivePeerDependencies:
-      - bufferutil
-      - utf-8-validate
-    dev: false
-
   /internal-slot/1.0.4:
     resolution: {integrity: sha512-tA8URYccNzMo94s5MQZgH8NB/XTa6HsOo0MLfXTKKEnHVVdegzaQoFZ7Jp44bdvLvY2waT5dc+j5ICEswhi7UQ==}
     engines: {node: '>= 0.4'}
@@ -5733,13 +5520,6 @@ packages:
     dependencies:
       call-bind: 1.0.2
       has-tostringtag: 1.0.0
-    dev: false
-
-  /is-builtin-module/3.2.0:
-    resolution: {integrity: sha512-phDA4oSGt7vl1n5tJvTWooWWAsXLY+2xCnxNqvKhGEzujg+A43wPlPOyDg3C8XQHN+6k/JTQWJ/j0dQh/qr+Hw==}
-    engines: {node: '>=6'}
-    dependencies:
-      builtin-modules: 3.3.0
     dev: false
 
   /is-callable/1.2.7:
@@ -6057,7 +5837,7 @@ packages:
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.12
       '@babel/plugin-syntax-typescript': 7.20.0_@babel+core@7.20.12
       '@babel/traverse': 7.20.12
-      '@babel/types': 7.20.7
+      '@babel/types': 7.21.2
       '@jest/expect-utils': 29.0.2
       '@jest/transform': 29.0.2
       '@jest/types': 29.0.2
@@ -6108,11 +5888,6 @@ packages:
       '@types/node': 18.13.0
       merge-stream: 2.0.0
       supports-color: 8.1.1
-    dev: false
-
-  /joycon/3.1.1:
-    resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
-    engines: {node: '>=10'}
     dev: false
 
   /js-sdsl/4.1.5:
@@ -6331,12 +6106,6 @@ packages:
     dependencies:
       js-tokens: 4.0.0
 
-  /loupe/2.3.4:
-    resolution: {integrity: sha512-OvKfgCC2Ndby6aSTREl5aCCPTNIzlDfQZvZxNUrBrihDhL3xcrYegTblhmEiCrg2kKQz4XsFIaemE5BF4ybSaQ==}
-    dependencies:
-      get-func-name: 2.0.0
-    dev: false
-
   /loupe/2.3.6:
     resolution: {integrity: sha512-RaPMZKiMy8/JruncMU5Bt6na1eftNoo++R4Y+N2FrxkDVTrGvcyzFTsaGif4QTeKESheMGegbhw6iUAq+5A8zA==}
     dependencies:
@@ -6364,13 +6133,6 @@ packages:
 
   /magic-string/0.25.9:
     resolution: {integrity: sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==}
-    dependencies:
-      sourcemap-codec: 1.4.8
-    dev: false
-
-  /magic-string/0.26.7:
-    resolution: {integrity: sha512-hX9XH3ziStPoPhJxLq1syWuZMxbDvGNbVchfrdCtanC7D13888bMFow61x8axrx+GfHLtVeAx2kxL7tTGRl+Ow==}
-    engines: {node: '>=12'}
     dependencies:
       sourcemap-codec: 1.4.8
     dev: false
@@ -6557,15 +6319,6 @@ packages:
   /mixme/0.5.4:
     resolution: {integrity: sha512-3KYa4m4Vlqx98GPdOHghxSdNtTvcP8E0kkaJ5Dlh+h2DRzF7zpuVVcA8B0QpKd11YJeP9QQ7ASkKzOeu195Wzw==}
     engines: {node: '>= 8.0.0'}
-    dev: false
-
-  /mlly/0.5.16:
-    resolution: {integrity: sha512-LaJ8yuh4v0zEmge/g3c7jjFlhoCPfQn6RCjXgm9A0Qiuochq4BcuOxVfWmdnCoLTlg2MV+hqhOek+W2OhG0Lwg==}
-    dependencies:
-      acorn: 8.8.1
-      pathe: 0.3.8
-      pkg-types: 0.3.5
-      ufo: 0.8.5
     dev: false
 
   /mlly/1.1.0:
@@ -7018,10 +6771,6 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /pathe/0.3.8:
-    resolution: {integrity: sha512-c71n61F1skhj/jzZe+fWE9XDoTYjWbUwIKVwFftZ5IOgiX44BVkTkD+/803YDgR50tqeO4eXWxLyVHBLWQAD1g==}
-    dev: false
-
   /pathe/1.1.0:
     resolution: {integrity: sha512-ODbEPR0KKHqECXW1GoxdDb+AZvULmXjVPy4rt+pGo2+TnjJTIPJQSVS6N63n8T2Ip+syHhbn52OewKicV0373w==}
     dev: false
@@ -7071,14 +6820,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       find-up: 4.1.0
-    dev: false
-
-  /pkg-types/0.3.5:
-    resolution: {integrity: sha512-VkxCBFVgQhNHYk9subx+HOhZ4jzynH11ah63LZsprTKwPCWG9pfWBlkElWFbvkP9BVR0dP1jS9xPdhaHQNK74Q==}
-    dependencies:
-      jsonc-parser: 3.2.0
-      mlly: 0.5.16
-      pathe: 0.3.8
     dev: false
 
   /pkg-types/1.0.1:
@@ -7288,17 +7029,6 @@ packages:
       - utf-8-validate
     dev: false
 
-  /react-dom/17.0.2_react@17.0.2:
-    resolution: {integrity: sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==}
-    peerDependencies:
-      react: 17.0.2
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react: 17.0.2
-      scheduler: 0.20.2
-    dev: false
-
   /react-dom/18.2.0_react@18.2.0:
     resolution: {integrity: sha512-6IMTriUmvsjHUjNtEDudZfuDQUoWXVxKHhlEGSk81n4YFS+r/Kl99wXiwlVXtPBtJenozv2P+hxDsw9eA7Xo6g==}
     peerDependencies:
@@ -7343,11 +7073,12 @@ packages:
     resolution: {integrity: sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==}
     dev: false
 
-  /react-keyed-flatten-children/1.3.0:
+  /react-keyed-flatten-children/1.3.0_react@18.2.0:
     resolution: {integrity: sha512-qB7A6n+NHU0x88qTZGAJw6dsqwI941jcRPBB640c/CyWqjPQQ+YUmXOuzPziuHb7iqplM3xksWAbGYwkQT0tXA==}
     peerDependencies:
       react: '>=15.0.0'
     dependencies:
+      react: 18.2.0
       react-is: 16.13.1
     dev: false
 
@@ -7376,18 +7107,6 @@ packages:
       react-dom: 18.2.0_react@18.2.0
       react-fast-compare: 3.2.0
       warning: 4.0.3
-    dev: false
-
-  /react-reconciler/0.26.2_react@17.0.2:
-    resolution: {integrity: sha512-nK6kgY28HwrMNwDnMui3dvm3rCFjZrcGiuwLc5COUipBK5hWHLOxMJhSnSomirqWwjPBJKV1QcbkI0VJr7Gl1Q==}
-    engines: {node: '>=0.10.0'}
-    peerDependencies:
-      react: ^17.0.2
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
-      react: 17.0.2
-      scheduler: 0.20.2
     dev: false
 
   /react-reconciler/0.26.2_react@18.2.0:
@@ -7442,19 +7161,6 @@ packages:
       use-sidecar: 1.1.2_fan5qbzahqtxlm5dzefqlqx5ia
     dev: false
 
-  /react-router-dom/6.0.0-beta.2_o2pg7ethq7rrtlls7f3e52nciu:
-    resolution: {integrity: sha512-ZOauHu+clEYCRsW77F21/q6Ou5zmJvL6FvKsbmvO+J+4e7OXglh0VJy8yph8xoz20Ak5UYDExubE6n5+2QP1pw==}
-    peerDependencies:
-      history: '>=5'
-      react: '>=16.8'
-      react-dom: '>=16.8'
-    dependencies:
-      history: 5.3.0
-      react: 17.0.2
-      react-dom: 17.0.2_react@17.0.2
-      react-router: 6.0.0-beta.2_history@5.3.0+react@17.0.2
-    dev: false
-
   /react-router-dom/6.4.3_biqbaboplfbrettd7655fr4n2y:
     resolution: {integrity: sha512-MiaYQU8CwVCaOfJdYvt84KQNjT78VF0TJrA17SIQgNHRvLnXDJO6qsFqq8F/zzB1BWZjCFIrQpu4QxcshitziQ==}
     engines: {node: '>=14'}
@@ -7466,16 +7172,6 @@ packages:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       react-router: 6.4.3_react@18.2.0
-    dev: false
-
-  /react-router/6.0.0-beta.2_history@5.3.0+react@17.0.2:
-    resolution: {integrity: sha512-oyVEfpVT9VbClWaZNNShfprq8HA5rSLfo/ZsXFT08/6mldM6onHzqr6Lc1ybBYEB7/c+rr1VOA99as7hEoAoXw==}
-    peerDependencies:
-      history: '>=5'
-      react: '>=16.8'
-    dependencies:
-      history: 5.3.0
-      react: 17.0.2
     dev: false
 
   /react-router/6.4.3_react@18.2.0:
@@ -7503,14 +7199,6 @@ packages:
       invariant: 2.2.4
       react: 18.2.0
       tslib: 2.4.0
-    dev: false
-
-  /react/17.0.2:
-    resolution: {integrity: sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==}
-    engines: {node: '>=0.10.0'}
-    dependencies:
-      loose-envify: 1.4.0
-      object-assign: 4.1.1
     dev: false
 
   /react/18.2.0:
@@ -7720,19 +7408,6 @@ packages:
       glob: 7.2.3
     dev: false
 
-  /rollup-plugin-dts/4.2.3_rollup@2.78.1:
-    resolution: {integrity: sha512-jlcpItqM2efqfIiKzDB/IKOS9E9fDvbkJSGw5GtK/PqPGS9eC3R3JKyw2VvpTktZA+TNgJRMu1NTv244aTUzzQ==}
-    engines: {node: '>=v12.22.12'}
-    peerDependencies:
-      rollup: ^2.55
-      typescript: ^4.1
-    dependencies:
-      magic-string: 0.26.7
-      rollup: 2.78.1
-    optionalDependencies:
-      '@babel/code-frame': 7.18.6
-    dev: false
-
   /rollup-plugin-dts/5.1.1_5bocdsq543f436r5sciojhuh3i:
     resolution: {integrity: sha512-zpgo52XmnLg8w4k3MScinFHZK1+ro6r7uVe34fJ0Ee8AM45FvgvTuvfWWaRgIpA4pQ1BHJuu2ospncZhkcJVeA==}
     engines: {node: '>=v14'}
@@ -7747,34 +7422,6 @@ packages:
       '@babel/code-frame': 7.18.6
     dev: false
 
-  /rollup-plugin-esbuild/4.10.1_odgv4gppx6j6fbpqvrdtgyyify:
-    resolution: {integrity: sha512-/ymcRB283zjFp1JTBXO8ekxv0c9vRc2L6OTljghsLthQ4vqeDSDWa9BVz1tHiVrx6SbUnUpDPLC0K/MXK7j5TA==}
-    engines: {node: '>=12'}
-    peerDependencies:
-      esbuild: '>=0.10.1'
-      rollup: ^1.20.0 || ^2.0.0
-    dependencies:
-      '@rollup/pluginutils': 4.2.1
-      debug: 4.3.4
-      es-module-lexer: 0.9.3
-      esbuild: 0.16.17
-      joycon: 3.1.1
-      jsonc-parser: 3.2.0
-      rollup: 2.78.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /rollup-plugin-node-externals/4.1.1_rollup@2.78.1:
-    resolution: {integrity: sha512-hiGCMTKHVoueaTmtcUv1KR0/dlNBuI9GYzHUlSHQbMd7T7yomYdXCFnBisoBqdZYy61EGAIfz8AvJaWWBho3Pg==}
-    engines: {node: '>=14.0.0'}
-    peerDependencies:
-      rollup: ^2.60.0
-    dependencies:
-      find-up: 5.0.0
-      rollup: 2.78.1
-    dev: false
-
   /rollup-plugin-node-externals/5.0.2_rollup@3.15.0:
     resolution: {integrity: sha512-UGAPdPjD0PPk4hNcHLnqwqsfNc/u0vaAjWnjkyS6j2jIMB4LLi1pW3TE01eaytJKZactNik2t8AQC33esS9GKw==}
     engines: {node: '>=14.0.0'}
@@ -7782,14 +7429,6 @@ packages:
       rollup: ^2.60.0 || ^3.0.0
     dependencies:
       rollup: 3.15.0
-    dev: false
-
-  /rollup/2.78.1:
-    resolution: {integrity: sha512-VeeCgtGi4P+o9hIg+xz4qQpRl6R401LWEXBmxYKOV4zlF82lyhgh2hTZnheFUbANE8l2A41F458iwj2vEYaXJg==}
-    engines: {node: '>=10.0.0'}
-    hasBin: true
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: false
 
   /rollup/2.79.1:
@@ -8010,6 +7649,9 @@ packages:
     engines: {node: '>=14'}
     peerDependencies:
       jest: '>=16'
+    peerDependenciesMeta:
+      jest:
+        optional: true
     dependencies:
       jest-diff: 29.0.2
       jest-snapshot: 29.0.2
@@ -8277,7 +7919,7 @@ packages:
     engines: {node: '>= 0.4'}
     dev: false
 
-  /sync-dependencies/1.0.4_kmihzdv5wva4zagwidt2n34234:
+  /sync-dependencies/1.0.4_kz43vugpxzze664l527a72jrc4:
     resolution: {integrity: sha512-1Jxm1CcjddtckYMeIVwx/S5Z+oze3NGXBD6uYDku5nDjcLa8HIKsgIg5FmzvrfAhACOnkI3xBkAseiUfx/sgsQ==}
     hasBin: true
     dependencies:
@@ -8533,10 +8175,6 @@ packages:
     engines: {node: '>=4.2.0'}
     hasBin: true
 
-  /ufo/0.8.5:
-    resolution: {integrity: sha512-e4+UtA5IRO+ha6hYklwj6r7BjiGMxS0O+UaSg9HbaTefg4kMkzj4tXzEBajRR+wkxf+golgAWKzLbytCUDMJAA==}
-    dev: false
-
   /ufo/1.0.1:
     resolution: {integrity: sha512-boAm74ubXHY7KJQZLlXrtMz52qFvpsbOxDcZOnw/Wf+LS4Mmyu7JxmzD4tDLtUQtmZECypJ0FrCz4QIe6dvKRA==}
     dev: false
@@ -8738,39 +8376,6 @@ packages:
       - sugarss
       - supports-color
       - terser
-    dev: false
-
-  /vite/3.2.5:
-    resolution: {integrity: sha512-4mVEpXpSOgrssFZAOmGIr85wPHKvaDAcXqxVxVRZhljkJOMZi1ibLibzjLHzJvcok8BMguLc7g1W6W/GqZbLdQ==}
-    engines: {node: ^14.18.0 || >=16.0.0}
-    hasBin: true
-    peerDependencies:
-      '@types/node': '>= 14'
-      less: '*'
-      sass: '*'
-      stylus: '*'
-      sugarss: '*'
-      terser: ^5.4.0
-    peerDependenciesMeta:
-      '@types/node':
-        optional: true
-      less:
-        optional: true
-      sass:
-        optional: true
-      stylus:
-        optional: true
-      sugarss:
-        optional: true
-      terser:
-        optional: true
-    dependencies:
-      esbuild: 0.15.18
-      postcss: 8.4.21
-      resolve: 1.22.1
-      rollup: 2.79.1
-    optionalDependencies:
-      fsevents: 2.3.2
     dev: false
 
   /vite/4.1.1_@types+node@18.13.0:


### PR DESCRIPTION
Now that we're using Vite again (#47) and various issues with SSR have been fixed, we don't need to mark [externals](https://vitejs.dev/guide/ssr.html#ssr-externals) ourselves any more.