### PR TITLE
Fix side-effects for entries

### DIFF
--- a/.changeset/olive-turkeys-change.md
+++ b/.changeset/olive-turkeys-change.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': patch
+---
+
+Don't put output files for entry points in `dist/side-effects`

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fixtures/braid-design-system"]
 	path = fixtures/braid-design-system
 	url = git@github.com:seek-oss/braid-design-system.git
-	branch = v32
+	branch = version-32

--- a/fixtures/with-side-effects/src/entries/reset.ts
+++ b/fixtures/with-side-effects/src/entries/reset.ts
@@ -1,1 +1,7 @@
-export * from '../lib/reset';
+import '../lib/reset';
+
+if (process.env.NO_SIDE_EFFECTS !== 'clearly') {
+  throw new Error('side-effect');
+}
+
+export * from '../lib/breakpoints';

--- a/packages/core/src/package/bundle.ts
+++ b/packages/core/src/package/bundle.ts
@@ -53,7 +53,12 @@ export const createBundle = async (
       rollupOptions: {
         input: entries.map(({ entryPath }) => entryPath),
         treeshake: {
-          moduleSideEffects: 'no-external',
+          moduleSideEffects(id, external) {
+            if (moduleHasSideEffects(id, packageJson.sideEffects)) {
+              return true;
+            }
+            return !external;
+          },
         },
         output: {
           ...outputOptions,

--- a/packages/core/src/package/bundle.ts
+++ b/packages/core/src/package/bundle.ts
@@ -85,7 +85,8 @@ export const createBundle = async (
 
             if (
               typeof packageJson.sideEffects !== 'boolean' &&
-              moduleHasSideEffects(srcPath, packageJson.sideEffects)
+              moduleHasSideEffects(srcPath, packageJson.sideEffects) &&
+              !getModuleInfo(id)?.isEntry
             ) {
               return replaceExtension(`${sideEffectsDir}/${srcPath}`);
             }

--- a/scripts/braid-fixture.sh
+++ b/scripts/braid-fixture.sh
@@ -3,7 +3,7 @@ set -eox pipefail
 
 repo=git@github.com:seek-oss/braid-design-system.git
 submodule=fixtures/braid-design-system
-branch=v32
+branch=version-32
 
 # Modified from https://stackoverflow.com/questions/45688121/how-to-do-submodule-sparse-checkout-with-git/45689692#45689692
 


### PR DESCRIPTION
Unfortunately, the `with-side-effects` fixture is too small to be able to reproduce the behaviour.

Running `crackle package` in Braid produces something like this:

Before:

```ts
// braid-design-system/dist/playroom/components.mjs
import { components } from './side-effects/path/to/playroom/components.mjs';

export { components };
```
(notice there is no check for `global.__IS_PLAYROOM_ENVIRONMENT__`)

After:

```ts
// braid-design-system/dist/playroom/components.mjs

// inlined components

if (global.__IS_PLAYROOM_ENVIRONMENT__ !== 'clearly') {
  throw new Error('o');
}

export { components };
```
