### PR TITLE
Restrict workflows on master and tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: push
+on:
+  push:
+    branches:
+      - '**'
+    tags-ignore:
+      - '**'
 
 env:
   CI: true

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -3,6 +3,7 @@ name: Snapshot
 on:
   push:
     branches-ignore:
+      - changeset-release/master
       - master
     tags-ignore:
       - '**'

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -1,6 +1,11 @@
 name: Snapshot
 
-on: push
+on:
+  push:
+    branches-ignore:
+      - master
+    tags-ignore:
+      - '**'
 
 env:
   CI: true


### PR DESCRIPTION
No need to snapshot when pushing to master and tags, obviously.
And running the CI workflow on tags is redundant because they're the same commits as master:

<img width="625" alt="image" src="https://user-images.githubusercontent.com/3297808/222280080-519fc83f-e17f-4654-9576-856cd19c7013.png">
