### PR TITLE
Build ESM and CJS bundles simultaneously

### DIFF
--- a/.changeset/breezy-mirrors-behave.md
+++ b/.changeset/breezy-mirrors-behave.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': patch
+---
+
+Upgrade Vite and Rollup to latest

--- a/.changeset/popular-radios-bathe.md
+++ b/.changeset/popular-radios-bathe.md
@@ -1,5 +1,0 @@
----
-'@crackle/core': minor
----
-
-Run DTS build once for all entries

--- a/.changeset/popular-radios-bathe.md
+++ b/.changeset/popular-radios-bathe.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': minor
+---
+
+Run DTS build once for all entries

--- a/.changeset/violet-spiders-cover.md
+++ b/.changeset/violet-spiders-cover.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': minor
+---
+
+Build ESM and CJS bundles simultaneously

--- a/.changeset/violet-spiders-cover.md
+++ b/.changeset/violet-spiders-cover.md
@@ -2,4 +2,24 @@
 '@crackle/core': minor
 ---
 
-Build ESM and CJS bundles simultaneously
+Build ESM and CJS bundles simultaneously and run DTS build once for all entries.
+
+This means building Braid is now twice as fast.
+
+#### `@crackle/cli@0.10.8`
+
+```
+➜ hyperfine "nr build"
+Benchmark 1: nr build
+  Time (mean ± σ):     28.016 s ±  0.630 s    [User: 39.951 s, System: 5.235 s]
+  Range (min … max):   26.568 s … 28.737 s    10 runs
+```
+
+#### This release
+
+```
+➜ hyperfine "nr build"
+Benchmark 1: nr build
+  Time (mean ± σ):     13.141 s ±  0.448 s    [User: 19.233 s, System: 2.623 s]
+  Range (min … max):   12.614 s … 14.199 s    10 runs
+```

--- a/.changeset/violet-spiders-cover.md
+++ b/.changeset/violet-spiders-cover.md
@@ -4,7 +4,7 @@
 
 Build ESM and CJS bundles simultaneously and run DTS build once for all entries.
 
-This means building Braid is now twice as fast.
+This means building Braid is now over twice as fast and Metropolis packages would see a huge boost as well.
 
 #### `@crackle/cli@0.10.8`
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -113,7 +113,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "resolve-from": "^5.0.0",
-    "rollup": "^3.10.0",
+    "rollup": "^3.18.0",
     "rollup-plugin-dts": "^5.1.1",
     "rollup-plugin-node-externals": "^5.0.2",
     "semver": "^7.3.8",
@@ -122,7 +122,7 @@
     "sort-package-json": "^1.57.0",
     "type-fest": "^3.2.0",
     "used-styles": "^2.4.1",
-    "vite": "^4.1.1"
+    "vite": "^4.1.4"
   },
   "devDependencies": {
     "@types/babel__core": "^7.1.20",

--- a/packages/core/src/build.ts
+++ b/packages/core/src/build.ts
@@ -8,7 +8,7 @@ import builtinModules from 'builtin-modules';
 import chalk from 'chalk';
 import { readJson } from 'fs-extra';
 import type { RollupOutput } from 'rollup';
-import type { InlineConfig as ViteConfig, Manifest } from 'vite';
+import type { UserConfig as ViteConfig, Manifest } from 'vite';
 import { build as viteBuild } from 'vite';
 
 import type { RenderAllPagesFn } from '../entries/types';

--- a/packages/core/src/package.ts
+++ b/packages/core/src/package.ts
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import fs from 'fs/promises';
 import path from 'path';
 
@@ -12,7 +11,7 @@ import { createBundle } from './package/bundle';
 import { createDtsBundle } from './package/dts';
 import { renderPackageJsonValidationError } from './reporters/package';
 import { renderBuildError } from './reporters/shared';
-import type { Format, PackageJson } from './types';
+import type { PackageJson } from './types';
 import {
   cleanPackageEntryPoints,
   createEntryPackageJsons,
@@ -60,32 +59,15 @@ const build = async (config: EnhancedConfig, packageName: string) => {
 
   const withLogging = async (
     bundle: typeof createBundle | typeof createDtsBundle,
-    format: Format,
+    label: string,
   ) => {
-    logger.info(`⚙️  Creating ${chalk.bold(format)} bundle...`);
-
-    const toRollupFormat = { esm: 'esm', cjs: 'cjs', dts: 'esm' } as const;
-
-    await bundle(config, entries, {
-      dir: config.root,
-      exports: 'auto',
-      format: toRollupFormat[format],
-      entryFileNames(chunkInfo) {
-        const entry = entries.find(
-          ({ entryPath }) => chunkInfo.facadeModuleId === entryPath,
-        );
-        assert(entry, `entry not found for ${chunkInfo.facadeModuleId}`);
-
-        return entry.getOutputPath(format, { from: config.root });
-      },
-    });
-
-    logger.info(`⚙️  Finished creating ${chalk.bold(format)} bundle`);
+    logger.info(`⚙️  Creating ${chalk.bold(label)} bundle...`);
+    await bundle(config, entries);
+    logger.info(`⚙️  Finished creating ${chalk.bold(label)} bundle`);
   };
 
   await Promise.all([
-    withLogging(createBundle, 'cjs'),
-    withLogging(createBundle, 'esm'),
+    withLogging(createBundle, 'esm/cjs'),
     withLogging(createDtsBundle, 'dts'),
   ]);
 

--- a/packages/core/src/package/bundle.ts
+++ b/packages/core/src/package/bundle.ts
@@ -12,7 +12,7 @@ import type { EnhancedConfig } from '../config';
 import { sideEffectsDir, srcDir, stylesDir } from '../constants';
 import { addVanillaDebugIds, externals } from '../plugins/rollup';
 import type { Format, PackageEntryPoint, PackageJson } from '../types';
-import { extensionForFormat } from '../utils/files';
+import { extensionForFormat, toRollupFormat } from '../utils/files';
 import { moduleHasSideEffects } from '../utils/side-effects';
 import { commonOutputOptions, commonViteConfig } from '../vite-config';
 
@@ -34,6 +34,7 @@ export const createBundle = async (
       ...commonOutputOptions(config, entries, format),
       inlineDynamicImports: false,
       interop: 'compat',
+      format: toRollupFormat(format),
       manualChunks(id, { getModuleInfo }) {
         const srcPath = replaceExtension(
           path.relative(`${config.root}/${srcDir}`, id),

--- a/packages/core/src/package/bundle.ts
+++ b/packages/core/src/package/bundle.ts
@@ -75,7 +75,7 @@ export const createBundle = async (
       minify: false,
       lib: {
         entry: entries.map(({ entryPath }) => entryPath),
-        // "build.lib.formats" will be ignored because "build.rollupOptions.output" is already an array format.
+        // don't need to specify "build.lib.formats" because it will be ignored when "build.rollupOptions.output" is an array
       },
       outDir: config.root,
       rollupOptions: {

--- a/packages/core/src/package/bundle.ts
+++ b/packages/core/src/package/bundle.ts
@@ -71,14 +71,14 @@ export const createBundle = async (
     plugins: [addVanillaDebugIds(config), externals(config, 'esm'), react()],
     logLevel: 'warn',
     build: {
-      // output directory is the package root, so we don't want to remove it
+      outDir: config.root,
+      // we don't want to remove the output of the DTS build
       emptyOutDir: false,
-      minify: false,
       lib: {
         entry: entries.map(({ entryPath }) => entryPath),
         // don't need to specify "build.lib.formats" because it will be ignored when "build.rollupOptions.output" is an array
       },
-      outDir: config.root,
+      minify: false,
       rollupOptions: {
         treeshake: {
           moduleSideEffects: 'no-external',

--- a/packages/core/src/package/dts.ts
+++ b/packages/core/src/package/dts.ts
@@ -1,37 +1,32 @@
-import type { OutputOptions } from 'rollup';
 import { rollup } from 'rollup';
 import dts from 'rollup-plugin-dts';
 
 import type { EnhancedConfig } from '../config';
 import { externals } from '../plugins/rollup';
 import type { PackageEntryPoint } from '../types';
-import { promiseMap } from '../utils/promise-map';
+import { commonOutputOptions } from '../vite-config';
 
 export const createDtsBundle = async (
   config: EnhancedConfig,
   entries: PackageEntryPoint[],
-  outputOptions: OutputOptions,
 ) => {
-  // We're bundling each entry separately to avoid chunking
-  await promiseMap(entries, async (entry) => {
-    const bundle = await rollup({
-      input: entry.entryPath,
-      plugins: [
-        externals(config),
-        dts({
-          respectExternal: true,
-          compilerOptions: config.dtsOptions as any,
-        }),
-      ],
-    });
-
-    await bundle.write({
-      ...outputOptions,
-      exports: 'named',
-      format: 'esm',
-      minifyInternalExports: false,
-    });
-
-    await bundle.close();
+  const bundle = await rollup({
+    input: entries.map((entry) => entry.entryPath),
+    plugins: [
+      externals(config),
+      dts({
+        respectExternal: true,
+        compilerOptions: config.dtsOptions as any,
+      }),
+    ],
   });
+
+  await bundle.write({
+    ...commonOutputOptions(config, entries, 'dts'),
+    exports: 'named',
+    format: 'esm',
+    experimentalMinChunkSize: Infinity,
+  });
+
+  await bundle.close();
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,19 +1,8 @@
 import type React from 'react';
-import type { InlineConfig } from 'vite';
 
 export type { PackageJson } from 'type-fest';
 
 export type Format = 'esm' | 'cjs' | 'dts';
-
-export type GetArrayType<T> = T extends Array<infer U> ? U : never;
-
-export type ManualChunksFn = NonNullable<
-  GetArrayType<
-    NonNullable<
-      NonNullable<NonNullable<InlineConfig['build']>['rollupOptions']>['output']
-    >
-  >['manualChunks']
->;
 
 type RoutePath = string;
 export type AppShell<MetadataType extends Record<string, any> | void = void> =

--- a/packages/core/src/utils/files.ts
+++ b/packages/core/src/utils/files.ts
@@ -79,3 +79,6 @@ export const emptyDir = async (dir: string, skip = ['.git']): Promise<void> => {
 
 export const extensionForFormat = (format: Format) =>
   (({ esm: 'mjs', cjs: 'cjs', dts: 'd.ts' } as const)[format]);
+
+export const toRollupFormat = (format: Format) =>
+  (({ esm: 'esm', cjs: 'cjs', dts: 'esm' } as const)[format]);

--- a/packages/core/src/vite-config.ts
+++ b/packages/core/src/vite-config.ts
@@ -1,25 +1,26 @@
 import assert from 'assert';
 
 import type { OutputOptions } from 'rollup';
-import type { InlineConfig } from 'vite';
+import type { UserConfig } from 'vite';
 
 import type { EnhancedConfig } from './config';
 import { distDir } from './constants';
 import type { Format, PackageEntryPoint } from './types';
 import { extensionForFormat } from './utils/files';
 
-export const commonViteConfig = (config: EnhancedConfig): InlineConfig => ({
-  root: config.root,
-  resolve: {
-    alias: {
-      __THE_ENTRY: config.appShell,
+export const commonViteConfig = (config: EnhancedConfig) =>
+  ({
+    root: config.root,
+    resolve: {
+      alias: {
+        __THE_ENTRY: config.appShell,
+      },
     },
-  },
-  define: {
-    'process.env.NODE_DEBUG': JSON.stringify(false),
-    global: JSON.stringify({}),
-  },
-});
+    define: {
+      'process.env.NODE_DEBUG': JSON.stringify(false),
+      global: JSON.stringify({}),
+    },
+  } satisfies UserConfig);
 
 export const commonOutputOptions = (
   config: EnhancedConfig,
@@ -29,7 +30,7 @@ export const commonOutputOptions = (
   const extension = extensionForFormat(format);
 
   return {
-    dir: distDir,
+    dir: `${config.root}/${distDir}`,
     hoistTransitiveImports: false,
     minifyInternalExports: false,
     entryFileNames(chunkInfo) {

--- a/packages/core/src/vite-config.ts
+++ b/packages/core/src/vite-config.ts
@@ -1,6 +1,12 @@
+import assert from 'assert';
+
+import type { OutputOptions } from 'rollup';
 import type { InlineConfig } from 'vite';
 
 import type { EnhancedConfig } from './config';
+import { distDir } from './constants';
+import type { Format, PackageEntryPoint } from './types';
+import { extensionForFormat } from './utils/files';
 
 export const commonViteConfig = (config: EnhancedConfig): InlineConfig => ({
   root: config.root,
@@ -14,3 +20,27 @@ export const commonViteConfig = (config: EnhancedConfig): InlineConfig => ({
     global: JSON.stringify({}),
   },
 });
+
+export const commonOutputOptions = (
+  config: EnhancedConfig,
+  entryPoints: PackageEntryPoint[],
+  format: Format = 'esm',
+) => {
+  const extension = extensionForFormat(format);
+
+  return {
+    dir: distDir,
+    hoistTransitiveImports: false,
+    minifyInternalExports: false,
+    entryFileNames(chunkInfo) {
+      const entry = entryPoints.find(
+        ({ entryPath }) => chunkInfo.facadeModuleId === entryPath,
+      );
+      assert(entry, `entry not found for ${chunkInfo.facadeModuleId}`);
+
+      return entry.getOutputPath(format);
+    },
+    chunkFileNames: ({ name }) =>
+      name.endsWith(extension) ? name : `${name}.chunk.${extension}`,
+  } satisfies OutputOptions;
+};

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -277,7 +277,7 @@ importers:
       react: ^18.2.0
       react-dom: ^18.2.0
       resolve-from: ^5.0.0
-      rollup: ^3.10.0
+      rollup: ^3.18.0
       rollup-plugin-dts: ^5.1.1
       rollup-plugin-node-externals: ^5.0.2
       semver: ^7.3.8
@@ -289,7 +289,7 @@ importers:
       type-fest: ^3.2.0
       typescript: '*'
       used-styles: ^2.4.1
-      vite: ^4.1.1
+      vite: ^4.1.4
     dependencies:
       '@babel/core': 7.20.12
       '@babel/plugin-syntax-jsx': 7.18.6_@babel+core@7.20.12
@@ -299,8 +299,8 @@ importers:
       '@ungap/structured-clone': 1.0.1
       '@vanilla-extract/css': 1.9.5
       '@vanilla-extract/integration': 6.0.1
-      '@vanilla-extract/vite-plugin': 3.7.0_vite@4.1.1
-      '@vitejs/plugin-react': 3.0.0_vite@4.1.1
+      '@vanilla-extract/vite-plugin': 3.7.0_vite@4.1.4
+      '@vitejs/plugin-react': 3.0.0_vite@4.1.4
       builtin-modules: 3.3.0
       chalk: 4.1.2
       ensure-gitignore: 1.2.0
@@ -317,16 +317,16 @@ importers:
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       resolve-from: 5.0.0
-      rollup: 3.15.0
-      rollup-plugin-dts: 5.1.1_5bocdsq543f436r5sciojhuh3i
-      rollup-plugin-node-externals: 5.0.2_rollup@3.15.0
+      rollup: 3.18.0
+      rollup-plugin-dts: 5.1.1_iv5r57o4732j2pxla245vzs2qi
+      rollup-plugin-node-externals: 5.0.2_rollup@3.18.0
       semver: 7.3.8
       serialize-javascript: 6.0.0
       serve-handler: 6.1.5
       sort-package-json: 1.57.0
       type-fest: 3.2.0
       used-styles: 2.4.1
-      vite: 4.1.1_@types+node@18.13.0
+      vite: 4.1.4_@types+node@18.13.0
     devDependencies:
       '@types/babel__core': 7.20.0
       '@types/express': 4.17.14
@@ -2641,6 +2641,11 @@ packages:
 
   /@types/lodash/4.14.186:
     resolution: {integrity: sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==}
+    dev: true
+
+  /@types/lodash/4.14.191:
+    resolution: {integrity: sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==}
+    dev: false
 
   /@types/mime/3.0.1:
     resolution: {integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==}
@@ -3010,7 +3015,7 @@ packages:
       '@vanilla-extract/css': 1.9.5
     dev: false
 
-  /@vanilla-extract/vite-plugin/3.7.0_vite@4.1.1:
+  /@vanilla-extract/vite-plugin/3.7.0_vite@4.1.4:
     resolution: {integrity: sha512-Sq54d1f+Bww09e9Q5acFsNKjlSYMQ4GewJthdb3CVwUeGVzV10rJBChw6zufs7ndmJVCzQ4I2IcNMy2OiAlkmA==}
     peerDependencies:
       vite: ^2.2.3 || ^3.0.0
@@ -3019,7 +3024,7 @@ packages:
       outdent: 0.8.0
       postcss: 8.4.21
       postcss-load-config: 3.1.4_postcss@8.4.21
-      vite: 4.1.1_@types+node@18.13.0
+      vite: 4.1.4_@types+node@18.13.0
     transitivePeerDependencies:
       - supports-color
       - ts-node
@@ -3040,7 +3045,7 @@ packages:
       - supports-color
     dev: false
 
-  /@vitejs/plugin-react/3.0.0_vite@4.1.1:
+  /@vitejs/plugin-react/3.0.0_vite@4.1.4:
     resolution: {integrity: sha512-1mvyPc0xYW5G8CHQvJIJXLoMjl5Ct3q2g5Y2s6Ccfgwm45y48LBvsla7az+GkkAtYikWQ4Lxqcsq5RHLcZgtNQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -3051,7 +3056,7 @@ packages:
       '@babel/plugin-transform-react-jsx-source': 7.19.6_@babel+core@7.20.12
       magic-string: 0.27.0
       react-refresh: 0.14.0
-      vite: 4.1.1_@types+node@18.13.0
+      vite: 4.1.4_@types+node@18.13.0
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -3474,7 +3479,7 @@ packages:
       '@capsizecss/vanilla-extract': 1.0.0_@vanilla-extract+css@1.9.5
       '@types/autosuggest-highlight': 3.2.0
       '@types/dedent': 0.7.0
-      '@types/lodash': 4.14.186
+      '@types/lodash': 4.14.191
       '@vanilla-extract/css': 1.9.5
       '@vanilla-extract/css-utils': 0.1.3
       '@vanilla-extract/dynamic': 2.0.3
@@ -7435,7 +7440,7 @@ packages:
       glob: 7.2.3
     dev: false
 
-  /rollup-plugin-dts/5.1.1_5bocdsq543f436r5sciojhuh3i:
+  /rollup-plugin-dts/5.1.1_iv5r57o4732j2pxla245vzs2qi:
     resolution: {integrity: sha512-zpgo52XmnLg8w4k3MScinFHZK1+ro6r7uVe34fJ0Ee8AM45FvgvTuvfWWaRgIpA4pQ1BHJuu2ospncZhkcJVeA==}
     engines: {node: '>=v14'}
     peerDependencies:
@@ -7443,19 +7448,19 @@ packages:
       typescript: ^4.1
     dependencies:
       magic-string: 0.27.0
-      rollup: 3.15.0
+      rollup: 3.18.0
       typescript: 4.9.4
     optionalDependencies:
       '@babel/code-frame': 7.18.6
     dev: false
 
-  /rollup-plugin-node-externals/5.0.2_rollup@3.15.0:
+  /rollup-plugin-node-externals/5.0.2_rollup@3.18.0:
     resolution: {integrity: sha512-UGAPdPjD0PPk4hNcHLnqwqsfNc/u0vaAjWnjkyS6j2jIMB4LLi1pW3TE01eaytJKZactNik2t8AQC33esS9GKw==}
     engines: {node: '>=14.0.0'}
     peerDependencies:
       rollup: ^2.60.0 || ^3.0.0
     dependencies:
-      rollup: 3.15.0
+      rollup: 3.18.0
     dev: false
 
   /rollup/2.79.1:
@@ -7466,8 +7471,8 @@ packages:
       fsevents: 2.3.2
     dev: false
 
-  /rollup/3.15.0:
-    resolution: {integrity: sha512-F9hrCAhnp5/zx/7HYmftvsNBkMfLfk/dXUh73hPSM2E3CRgap65orDNJbLetoiUFwSAk6iHPLvBrZ5iHYvzqsg==}
+  /rollup/3.18.0:
+    resolution: {integrity: sha512-J8C6VfEBjkvYPESMQYxKHxNOh4A5a3FlP+0BETGo34HEcE4eTlgCrO2+eWzlu2a/sHs2QUkZco+wscH7jhhgWg==}
     engines: {node: '>=14.18.0', npm: '>=8.0.0'}
     hasBin: true
     optionalDependencies:
@@ -8394,7 +8399,7 @@ packages:
       picocolors: 1.0.0
       source-map: 0.6.1
       source-map-support: 0.5.21
-      vite: 4.1.1_@types+node@18.13.0
+      vite: 4.1.4_@types+node@18.13.0
     transitivePeerDependencies:
       - '@types/node'
       - less
@@ -8405,8 +8410,8 @@ packages:
       - terser
     dev: false
 
-  /vite/4.1.1_@types+node@18.13.0:
-    resolution: {integrity: sha512-LM9WWea8vsxhr782r9ntg+bhSFS06FJgCvvB0+8hf8UWtvaiDagKYWXndjfX6kGl74keHJUcpzrQliDXZlF5yg==}
+  /vite/4.1.4_@types+node@18.13.0:
+    resolution: {integrity: sha512-3knk/HsbSTKEin43zHu7jTwYWv81f8kgAL99G5NWBcA1LKvtvcVAC4JjBH1arBunO9kQka+1oGbrMKOjk4ZrBg==}
     engines: {node: ^14.18.0 || >=16.0.0}
     hasBin: true
     peerDependencies:
@@ -8434,7 +8439,7 @@ packages:
       esbuild: 0.16.17
       postcss: 8.4.21
       resolve: 1.22.1
-      rollup: 3.15.0
+      rollup: 3.18.0
     optionalDependencies:
       fsevents: 2.3.2
     dev: false
@@ -8482,7 +8487,7 @@ packages:
       tinybench: 2.3.1
       tinypool: 0.3.1
       tinyspy: 1.0.2
-      vite: 4.1.1_@types+node@18.13.0
+      vite: 4.1.4_@types+node@18.13.0
       vite-node: 0.28.5_@types+node@18.13.0
       why-is-node-running: 2.2.2
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -135,7 +135,7 @@ importers:
     devDependencies:
       '@crackle/cli': link:../../packages/cli
       '@crackle/core': link:../../packages/core
-      '@types/lodash': 4.14.186
+      '@types/lodash': 4.14.191
       '@types/react': 18.0.28
       '@types/react-dom': 18.0.11
 
@@ -587,19 +587,6 @@ packages:
       '@babel/helper-annotate-as-pure': 7.18.6
       '@babel/helper-environment-visitor': 7.18.9
       '@babel/helper-wrap-function': 7.19.0
-      '@babel/types': 7.21.2
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
-
-  /@babel/helper-replace-supers/7.18.9:
-    resolution: {integrity: sha512-dNsWibVI4lNT6HiuOIBr1oyxo40HvIVmbwPUm3XZ7wMh4k2WxrxTqZwSqw/eEmXDS9np0ey5M2bz9tBmO9c+YQ==}
-    engines: {node: '>=6.9.0'}
-    dependencies:
-      '@babel/helper-environment-visitor': 7.18.9
-      '@babel/helper-member-expression-to-functions': 7.21.0
-      '@babel/helper-optimise-call-expression': 7.18.6
-      '@babel/traverse': 7.20.12
       '@babel/types': 7.21.2
     transitivePeerDependencies:
       - supports-color
@@ -1313,7 +1300,7 @@ packages:
     dependencies:
       '@babel/core': 7.20.12
       '@babel/helper-plugin-utils': 7.20.2
-      '@babel/helper-replace-supers': 7.18.9
+      '@babel/helper-replace-supers': 7.20.7
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -2639,13 +2626,8 @@ packages:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
     dev: false
 
-  /@types/lodash/4.14.186:
-    resolution: {integrity: sha512-eHcVlLXP0c2FlMPm56ITode2AgLMSa6aJ05JTTbYbI+7EMkCEE5qk2E41d5g2lCVTqRe0GnnRFurmlCsDODrPw==}
-    dev: true
-
   /@types/lodash/4.14.191:
     resolution: {integrity: sha512-BdZ5BCCvho3EIXw6wUCXHe7rS53AIDPLE+JzwgT+OsJk53oBfbSmZZ7CX4VaRoN78N+TJpFi9QPlfIVNmJYWxQ==}
-    dev: false
 
   /@types/mime/3.0.1:
     resolution: {integrity: sha512-Y4XFY5VJAuw0FgAqPNd6NNoV44jbq9Bz2L7Rh/J6jLTiHBSBJa9fxqQIvkIld4GsoDOcCbvzOUAbLPsSKKg+uA==}


### PR DESCRIPTION
- Upgrade Vite and Rollup to latest
- Build ESM and CJS bundles simultaneously
- Run DTS build once for all entries. Previously each entry was built separately to avoid having `.d.ts` chunks, but now we can use [`experimentalMinChunkSize`](https://rollupjs.org/configuration-options/#output-experimentalminchunksize) to achieve the same result

### Benchmark results (packaging Braid)

`master`:
```
➜ hyperfine "nr build"
Benchmark 1: nr build
  Time (mean ± σ):     28.016 s ±  0.630 s    [User: 39.951 s, System: 5.235 s]
  Range (min … max):   26.568 s … 28.737 s    10 runs
```

This branch:
```
➜ hyperfine "nr build"                                     
Benchmark 1: nr build
  Time (mean ± σ):     13.141 s ±  0.448 s    [User: 19.233 s, System: 2.623 s]
  Range (min … max):   12.614 s … 14.199 s    10 runs
```