### PR TITLE
Create an `index.d.ts` redirect for backwards-compatible entry points

### DIFF
--- a/.changeset/hip-ladybugs-fold.md
+++ b/.changeset/hip-ladybugs-fold.md
@@ -1,0 +1,7 @@
+---
+'@crackle/core': minor
+---
+
+Create an `index.d.ts` redirect for backwards-compatible entry points.
+
+This prevents VS Code from auto-importing entry points from `dist/`. For example, wanting to use [Braid's CSS variables](https://seek-oss.github.io/braid-design-system/css/vars) (`vars`) VS Code would suggest `braid-design-system/dist/css` instead of `braid-design-system/css`.

--- a/fixtures/multi-entry-library/src/entries/themes/apac.ts
+++ b/fixtures/multi-entry-library/src/entries/themes/apac.ts
@@ -1,1 +1,1 @@
-export const theme = 'I am theme';
+export default 'I am theme';

--- a/packages/core/src/utils/dev-declaration-files.ts
+++ b/packages/core/src/utils/dev-declaration-files.ts
@@ -1,7 +1,4 @@
-import fs from 'fs/promises';
 import path from 'path';
-
-import { parse } from 'es-module-lexer';
 
 import type { EnhancedConfig } from '../config';
 
@@ -9,17 +6,10 @@ import {
   createEntryPackageJsons,
   getPackageEntryPoints,
   getPackages,
+  hasDefaultExport,
 } from './entry-points';
 import { writeIfRequired } from './files';
 import { promiseMap } from './promise-map';
-
-const hasDefaultExport = async (filePath: string) => {
-  const fileContents = await fs.readFile(filePath, 'utf-8');
-  // `parse` returns a promise if not initialised
-  // https://github.com/guybedford/es-module-lexer/blob/1.1.0/src/lexer.ts#L156-L159
-  const [, exports] = await parse(fileContents, filePath);
-  return exports.some((specifier) => specifier.n === 'default');
-};
 
 export const generateDevDeclarationFiles = async (config: EnhancedConfig) => {
   const packages = await getPackages(config);

--- a/packages/core/src/utils/entry-points.test.ts
+++ b/packages/core/src/utils/entry-points.test.ts
@@ -1,3 +1,4 @@
+import _ from 'lodash';
 import { fs, vol } from 'memfs';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 
@@ -18,10 +19,10 @@ describe('getPackageEntryPoints', () => {
     vol.reset();
     vol.fromJSON(
       {
-        'src/index.ts': '__stuff__',
-        'src/entries/components.ts': '__stuff__',
-        'src/entries/extras.ts': '__stuff__',
-        'src/entries/themes/apac.ts': '__stuff__',
+        'src/index.ts': 'export default {}',
+        'src/entries/components.ts': 'export const components = {}',
+        'src/entries/extras.ts': 'export const extras = {}',
+        'src/entries/themes/apac.ts': 'export default {}',
       },
       packageRoot,
     );
@@ -129,26 +130,30 @@ describe('getPackageEntryPoints', () => {
 
     expect(vol.toJSON()).toMatchInlineSnapshot(`
       {
+        "/__ROOT__/multi-entry/components/index.d.ts": "export * from "../dist/components";",
         "/__ROOT__/multi-entry/components/package.json": "{
         "main": "../dist/components.cjs",
         "module": "../dist/components.mjs",
-        "types": "../dist/components.d.ts"
+        "types": "./index.d.ts"
       }
       ",
+        "/__ROOT__/multi-entry/extras/index.d.ts": "export * from "../dist/extras";",
         "/__ROOT__/multi-entry/extras/package.json": "{
         "main": "../dist/extras.cjs",
         "module": "../dist/extras.mjs",
-        "types": "../dist/extras.d.ts"
+        "types": "./index.d.ts"
       }
       ",
-        "/__ROOT__/multi-entry/src/entries/components.ts": "__stuff__",
-        "/__ROOT__/multi-entry/src/entries/extras.ts": "__stuff__",
-        "/__ROOT__/multi-entry/src/entries/themes/apac.ts": "__stuff__",
-        "/__ROOT__/multi-entry/src/index.ts": "__stuff__",
+        "/__ROOT__/multi-entry/src/entries/components.ts": "export const components = {}",
+        "/__ROOT__/multi-entry/src/entries/extras.ts": "export const extras = {}",
+        "/__ROOT__/multi-entry/src/entries/themes/apac.ts": "export default {}",
+        "/__ROOT__/multi-entry/src/index.ts": "export default {}",
+        "/__ROOT__/multi-entry/themes/apac/index.d.ts": "export * from "../../dist/themes/apac";
+      export { default } from "../../dist/themes/apac";",
         "/__ROOT__/multi-entry/themes/apac/package.json": "{
         "main": "../../dist/themes/apac.cjs",
         "module": "../../dist/themes/apac.mjs",
-        "types": "../../dist/themes/apac.d.ts"
+        "types": "./index.d.ts"
       }
       ",
       }
@@ -166,10 +171,10 @@ describe('getPackageEntryPoints', () => {
         "/__ROOT__/multi-entry/components": null,
         "/__ROOT__/multi-entry/dist": null,
         "/__ROOT__/multi-entry/extras": null,
-        "/__ROOT__/multi-entry/src/entries/components.ts": "__stuff__",
-        "/__ROOT__/multi-entry/src/entries/extras.ts": "__stuff__",
-        "/__ROOT__/multi-entry/src/entries/themes/apac.ts": "__stuff__",
-        "/__ROOT__/multi-entry/src/index.ts": "__stuff__",
+        "/__ROOT__/multi-entry/src/entries/components.ts": "export const components = {}",
+        "/__ROOT__/multi-entry/src/entries/extras.ts": "export const extras = {}",
+        "/__ROOT__/multi-entry/src/entries/themes/apac.ts": "export default {}",
+        "/__ROOT__/multi-entry/src/index.ts": "export default {}",
         "/__ROOT__/multi-entry/themes/apac": null,
       }
     `);

--- a/packages/core/src/utils/entry-points.test.ts
+++ b/packages/core/src/utils/entry-points.test.ts
@@ -129,14 +129,16 @@ describe('getPackageEntryPoints', () => {
 
     expect(vol.toJSON()).toMatchInlineSnapshot(`
       {
-        "/___/components/index.d.ts": "export * from "../dist/components";",
+        "/___/components/index.d.ts": "export * from "../dist/components";
+      ",
         "/___/components/package.json": "{
         "main": "../dist/components.cjs",
         "module": "../dist/components.mjs",
         "types": "./index.d.ts"
       }
       ",
-        "/___/extras/index.d.ts": "export * from "../dist/extras";",
+        "/___/extras/index.d.ts": "export * from "../dist/extras";
+      ",
         "/___/extras/package.json": "{
         "main": "../dist/extras.cjs",
         "module": "../dist/extras.mjs",
@@ -148,7 +150,8 @@ describe('getPackageEntryPoints', () => {
         "/___/src/entries/themes/apac.ts": "export default {}",
         "/___/src/index.ts": "export default {}",
         "/___/themes/apac/index.d.ts": "export * from "../../dist/themes/apac";
-      export { default } from "../../dist/themes/apac";",
+      export { default } from "../../dist/themes/apac";
+      ",
         "/___/themes/apac/package.json": "{
         "main": "../../dist/themes/apac.cjs",
         "module": "../../dist/themes/apac.mjs",

--- a/packages/core/src/utils/entry-points.test.ts
+++ b/packages/core/src/utils/entry-points.test.ts
@@ -1,4 +1,3 @@
-import _ from 'lodash';
 import { fs, vol } from 'memfs';
 import { beforeEach, describe, expect, test, vi } from 'vitest';
 

--- a/packages/core/src/utils/entry-points.test.ts
+++ b/packages/core/src/utils/entry-points.test.ts
@@ -13,7 +13,7 @@ vi.mock('fs/promises', () => ({ default: fs.promises }));
 vi.mock('fs-extra', () => ({ default: { ...fs, ...fs.promises } }));
 
 describe('getPackageEntryPoints', () => {
-  const packageRoot = '/__ROOT__/multi-entry';
+  const packageRoot = '/___';
 
   beforeEach(() => {
     vol.reset();
@@ -35,35 +35,35 @@ describe('getPackageEntryPoints', () => {
       [
         {
           "entryName": "dist",
-          "entryPath": "/__ROOT__/multi-entry/src/index.ts",
+          "entryPath": "/___/src/index.ts",
           "getOutputPath": [Function],
           "isDefaultEntry": true,
-          "outputDir": "/__ROOT__/multi-entry/dist",
-          "packageDir": "/__ROOT__/multi-entry/dist",
+          "outputDir": "/___/dist",
+          "packageDir": "/___/dist",
         },
         {
           "entryName": "components",
-          "entryPath": "/__ROOT__/multi-entry/src/entries/components.ts",
+          "entryPath": "/___/src/entries/components.ts",
           "getOutputPath": [Function],
           "isDefaultEntry": false,
-          "outputDir": "/__ROOT__/multi-entry/dist",
-          "packageDir": "/__ROOT__/multi-entry/components",
+          "outputDir": "/___/dist",
+          "packageDir": "/___/components",
         },
         {
           "entryName": "extras",
-          "entryPath": "/__ROOT__/multi-entry/src/entries/extras.ts",
+          "entryPath": "/___/src/entries/extras.ts",
           "getOutputPath": [Function],
           "isDefaultEntry": false,
-          "outputDir": "/__ROOT__/multi-entry/dist",
-          "packageDir": "/__ROOT__/multi-entry/extras",
+          "outputDir": "/___/dist",
+          "packageDir": "/___/extras",
         },
         {
           "entryName": "themes/apac",
-          "entryPath": "/__ROOT__/multi-entry/src/entries/themes/apac.ts",
+          "entryPath": "/___/src/entries/themes/apac.ts",
           "getOutputPath": [Function],
           "isDefaultEntry": false,
-          "outputDir": "/__ROOT__/multi-entry/dist",
-          "packageDir": "/__ROOT__/multi-entry/themes/apac",
+          "outputDir": "/___/dist",
+          "packageDir": "/___/themes/apac",
         },
       ]
     `);
@@ -130,27 +130,27 @@ describe('getPackageEntryPoints', () => {
 
     expect(vol.toJSON()).toMatchInlineSnapshot(`
       {
-        "/__ROOT__/multi-entry/components/index.d.ts": "export * from "../dist/components";",
-        "/__ROOT__/multi-entry/components/package.json": "{
+        "/___/components/index.d.ts": "export * from "../dist/components";",
+        "/___/components/package.json": "{
         "main": "../dist/components.cjs",
         "module": "../dist/components.mjs",
         "types": "./index.d.ts"
       }
       ",
-        "/__ROOT__/multi-entry/extras/index.d.ts": "export * from "../dist/extras";",
-        "/__ROOT__/multi-entry/extras/package.json": "{
+        "/___/extras/index.d.ts": "export * from "../dist/extras";",
+        "/___/extras/package.json": "{
         "main": "../dist/extras.cjs",
         "module": "../dist/extras.mjs",
         "types": "./index.d.ts"
       }
       ",
-        "/__ROOT__/multi-entry/src/entries/components.ts": "export const components = {}",
-        "/__ROOT__/multi-entry/src/entries/extras.ts": "export const extras = {}",
-        "/__ROOT__/multi-entry/src/entries/themes/apac.ts": "export default {}",
-        "/__ROOT__/multi-entry/src/index.ts": "export default {}",
-        "/__ROOT__/multi-entry/themes/apac/index.d.ts": "export * from "../../dist/themes/apac";
+        "/___/src/entries/components.ts": "export const components = {}",
+        "/___/src/entries/extras.ts": "export const extras = {}",
+        "/___/src/entries/themes/apac.ts": "export default {}",
+        "/___/src/index.ts": "export default {}",
+        "/___/themes/apac/index.d.ts": "export * from "../../dist/themes/apac";
       export { default } from "../../dist/themes/apac";",
-        "/__ROOT__/multi-entry/themes/apac/package.json": "{
+        "/___/themes/apac/package.json": "{
         "main": "../../dist/themes/apac.cjs",
         "module": "../../dist/themes/apac.mjs",
         "types": "./index.d.ts"
@@ -168,14 +168,14 @@ describe('getPackageEntryPoints', () => {
 
     expect(vol.toJSON()).toMatchInlineSnapshot(`
       {
-        "/__ROOT__/multi-entry/components": null,
-        "/__ROOT__/multi-entry/dist": null,
-        "/__ROOT__/multi-entry/extras": null,
-        "/__ROOT__/multi-entry/src/entries/components.ts": "export const components = {}",
-        "/__ROOT__/multi-entry/src/entries/extras.ts": "export const extras = {}",
-        "/__ROOT__/multi-entry/src/entries/themes/apac.ts": "export default {}",
-        "/__ROOT__/multi-entry/src/index.ts": "export default {}",
-        "/__ROOT__/multi-entry/themes/apac": null,
+        "/___/components": null,
+        "/___/dist": null,
+        "/___/extras": null,
+        "/___/src/entries/components.ts": "export const components = {}",
+        "/___/src/entries/extras.ts": "export const extras = {}",
+        "/___/src/entries/themes/apac.ts": "export default {}",
+        "/___/src/index.ts": "export default {}",
+        "/___/themes/apac": null,
       }
     `);
   });

--- a/packages/core/src/utils/entry-points.ts
+++ b/packages/core/src/utils/entry-points.ts
@@ -135,7 +135,7 @@ export const createEntryPackageJsons = async (
         declarationLines.push(`export { default } from "${typesOutputPath}";`);
       }
 
-      const typesPath = './index.d.ts';
+      const typesPath = `./index.${extensionForFormat('dts')}`;
       await writeIfRequired({
         dir: entryPoint.packageDir,
         fileName: typesPath,

--- a/packages/core/src/utils/entry-points.ts
+++ b/packages/core/src/utils/entry-points.ts
@@ -139,7 +139,7 @@ export const createEntryPackageJsons = async (
       await writeIfRequired({
         dir: entryPoint.packageDir,
         fileName: typesPath,
-        contents: declarationLines.join('\n'),
+        contents: `${declarationLines.join('\n')}\n`,
       });
 
       await writePackageJson({

--- a/scripts/add-fixture.ts
+++ b/scripts/add-fixture.ts
@@ -92,19 +92,24 @@ const template = {
   console.log();
 
   const packageDir = path.join(fixturesDir, answers.name);
+  const packageJsonPath = path.join(packageDir, 'package.json');
 
   const packageJson = template.packageJson(answers);
   const index = template.index(answers);
 
   await fs.mkdirp(path.join(packageDir, 'src'));
-  await fs.writeJson(path.join(packageDir, 'package.json'), packageJson, {
-    spaces: 2,
-  });
+  await fs.writeJson(packageJsonPath, packageJson, { spaces: 2 });
   await fs.writeFile(path.join(packageDir, 'src/index.ts'), index);
 
-  console.log(packageJson);
-  console.log();
-
+  try {
+    console.log('Trying `bat`...');
+    await run(`bat ${packageJsonPath}`);
+  } catch (e: any) {
+    console.log('File:', packageJsonPath);
+    console.log(await fs.readFile(packageJsonPath, { encoding: 'utf8' }));
+  }
   await run('pnpm install', { cwd: packageDir });
   await run(`pnpm --filter='${packageJson.name}' fix`);
+
+  console.log('Done.');
 })();

--- a/tests/__snapshots__/package.test.ts.snap
+++ b/tests/__snapshots__/package.test.ts.snap
@@ -271,9 +271,9 @@ type Config = Awaited<ReturnType<typeof resolveConfig>>;
 declare const logger: () => void;
 declare const calcAndLog: (a: number, b: number, fn: MathsFn) => void;
 
-declare const theme = "I am theme";
+declare const _default: "I am theme";
 
-export { Config, JobSummary, add, calcAndLog, logger, theme };
+export { Config, JobSummary, _default, add, calcAndLog, logger };
 `;
 
 exports[`package > fixture multi-entry-library > dist/components.cjs 1`] = `
@@ -463,17 +463,16 @@ export {
 
 exports[`package > fixture multi-entry-library > dist/themes/apac.cjs 1`] = `
 "use strict";
-Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
-const theme = "I am theme";
-exports.theme = theme;
+const apac = "I am theme";
+module.exports = apac;
 `;
 
-exports[`package > fixture multi-entry-library > dist/themes/apac.d.ts 1`] = `export { theme } from '../apac.chunk.js';`;
+exports[`package > fixture multi-entry-library > dist/themes/apac.d.ts 1`] = `export { _default as default } from '../apac.chunk.js';`;
 
 exports[`package > fixture multi-entry-library > dist/themes/apac.mjs 1`] = `
-const theme = "I am theme";
+const apac = "I am theme";
 export {
-  theme
+  apac as default
 };
 `;
 


### PR DESCRIPTION
This prevents VS Code from auto-importing entry points from `dist/`. For example, wanting to use [Braid's CSS variables](https://seek-oss.github.io/braid-design-system/css/vars) (`vars`) VS Code would suggest `braid-design-system/dist/css` instead of `braid-design-system/css`.

The solution is to create an `index.d.ts` next to `entry/path/package.json` which re-exports from `dist/entry/path.d.ts`. This works because re-exports tend to shadow their sources in completions.