### PR TITLE
Remove `dist-render` from `.gitignore`

### DIFF
--- a/.changeset/cold-tigers-sing.md
+++ b/.changeset/cold-tigers-sing.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': patch
+---
+
+Remove `dist-render` from `.gitignore`

--- a/fixtures/braid-site/.gitignore
+++ b/fixtures/braid-site/.gitignore
@@ -1,4 +1,3 @@
 # managed by crackle
 /dist
-/dist-render
 # end managed by crackle

--- a/fixtures/esm-patch-imports/.gitignore
+++ b/fixtures/esm-patch-imports/.gitignore
@@ -1,4 +1,3 @@
 # managed by crackle
 /dist
-/dist-render
 # end managed by crackle

--- a/fixtures/library-with-docs/.gitignore
+++ b/fixtures/library-with-docs/.gitignore
@@ -1,4 +1,3 @@
 # managed by crackle
 /dist
-/dist-render
 # end managed by crackle

--- a/fixtures/multi-entry-library/.gitignore
+++ b/fixtures/multi-entry-library/.gitignore
@@ -1,7 +1,6 @@
 # managed by crackle
 /components
 /dist
-/dist-render
 /extras
 /themes/apac
 # end managed by crackle

--- a/fixtures/single-entry-library/.gitignore
+++ b/fixtures/single-entry-library/.gitignore
@@ -1,4 +1,3 @@
 # managed by crackle
 /dist
-/dist-render
 # end managed by crackle

--- a/fixtures/with-dep-hidden-package-json/.gitignore
+++ b/fixtures/with-dep-hidden-package-json/.gitignore
@@ -1,4 +1,3 @@
 # managed by crackle
 /dist
-/dist-render
 # end managed by crackle

--- a/fixtures/with-flatten-children/.gitignore
+++ b/fixtures/with-flatten-children/.gitignore
@@ -1,4 +1,3 @@
 # managed by crackle
 /dist
-/dist-render
 # end managed by crackle

--- a/fixtures/with-side-effects/.gitignore
+++ b/fixtures/with-side-effects/.gitignore
@@ -2,6 +2,5 @@
 /css
 /css-more
 /dist
-/dist-render
 /reset
 # end managed by crackle

--- a/packages/core/src/utils/gitignore.ts
+++ b/packages/core/src/utils/gitignore.ts
@@ -12,7 +12,6 @@ export const updateGitignore = async (
   const entryNames = new Set(entryPoints.map((entry) => entry.entryName));
 
   entryNames.add(siteBuild.outDir);
-  entryNames.add(siteBuild.rendererDir);
 
   await ensureGitignore({
     filepath: path.join(packageRoot, '.gitignore'),

--- a/scripts/braid-fixture.ts
+++ b/scripts/braid-fixture.ts
@@ -33,42 +33,42 @@ const repo = 'git@github.com:seek-oss/braid-design-system.git';
 const submodule = 'fixtures/braid-design-system';
 const branch = argv.branch;
 
-const fromRoot = (location: string) => path.join(__dirname, '..', location);
+const fromRoot = (location: string) => path.resolve(__dirname, '..', location);
 const run: typeof _run = (command) => _run(command, { cwd: fromRoot('.') });
 const clean = async (location: string) =>
   (await fse.exists(fromRoot(location))) && run(`rm -fr ${location}`);
 
-//  Modified from https://stackoverflow.com/questions/45688121/how-to-do-submodule-sparse-checkout-with-git/45689692//45689692
+// Modified from https://stackoverflow.com/questions/45688121/how-to-do-submodule-sparse-checkout-with-git/45689692//45689692
 
 if (argv.clone) {
   // Clean submodule dirs so we can start fresh
   await clean(`.git/modules/${submodule}`);
   await clean(submodule);
 
+  // Can't use SSH in CI and we don't need to push, so we use HTTPS instead
   if (process.env.CI) {
     await run(
       'git config --global url."https://github.com/".insteadOf "git@github.com:"',
     );
   }
 
-  //  Checkout the to-be submodule
+  // Checkout the to-be submodule
   await run(
     `git clone --depth=1 --no-checkout -b ${branch} ${repo} ${submodule}`,
   );
 }
 
 if (argv.absorb) {
-  //  Add as a submodule
+  // Add as a submodule
   await run(`git submodule add -b ${branch} --force ${repo} ${submodule}`);
 
-  //  Move the .git dir from $fixture/.git into parent repo's .git
+  // Move the .git dir from $fixture/.git into parent repo's .git
   await run(`git submodule absorbgitdirs`);
 
-  //  Note there is no "submodule.sub.sparsecheckout" key
+  // Note there is no "submodule.sub.sparsecheckout" key
   await run(`git -C ${submodule} config core.sparseCheckout true`);
 
-  // This pattern determines which files within $repo get checked out.
-  // Note quoted wildcards to avoid their expansion by shell
+  // This pattern determines which files within $repo get checked out
   await fse.appendFile(
     fromRoot(`.git/modules/${submodule}/info/sparse-checkout`),
     dedent`
@@ -84,9 +84,7 @@ await run(`git submodule update --force --checkout ${submodule}`);
 // End of submodule code
 
 const runInBraid: typeof _run = (command) =>
-  _run(command, {
-    cwd: fromRoot(path.join(submodule, `packages/braid-design-system`)),
-  });
+  _run(command, { cwd: fromRoot(`${submodule}/packages/braid-design-system`) });
 
 await runInBraid(`pnpm install --no-frozen-lockfile`);
 


### PR DESCRIPTION
We'll add it back when we have a clear direction for site build.

Plus a forgotten commit from #87 