### PR TITLE
Don't reconcile import specifiers for `.d.ts` files

### DIFF
--- a/.changeset/strong-mice-reflect.md
+++ b/.changeset/strong-mice-reflect.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': patch
+---
+
+Don't reconcile import specifiers for `.d.ts` files

--- a/.prettierignore
+++ b/.prettierignore
@@ -46,6 +46,10 @@ fixtures/with-flatten-children/dist
 # end managed by crackle
 
 # managed by crackle
+fixtures/with-graphql-schema-types/dist
+# end managed by crackle
+
+# managed by crackle
 fixtures/with-side-effects/css
 fixtures/with-side-effects/css-more
 fixtures/with-side-effects/dist

--- a/fixtures/with-graphql-schema-types/.gitignore
+++ b/fixtures/with-graphql-schema-types/.gitignore
@@ -1,0 +1,3 @@
+# managed by crackle
+/dist
+# end managed by crackle

--- a/fixtures/with-graphql-schema-types/graphql-schema/package.json
+++ b/fixtures/with-graphql-schema-types/graphql-schema/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "@crackle-fixtures/graphql-schema",
+  "version": "1.0.0",
+  "private": true,
+  "main": "schema.json",
+  "files": [
+    "schema.json",
+    "schema.gql",
+    "possible-types.json",
+    "types.ts"
+  ],
+  "types": "types.ts"
+}

--- a/fixtures/with-graphql-schema-types/graphql-schema/types.ts
+++ b/fixtures/with-graphql-schema-types/graphql-schema/types.ts
@@ -1,0 +1,1 @@
+export type Maybe<T> = T | null;

--- a/fixtures/with-graphql-schema-types/package.json
+++ b/fixtures/with-graphql-schema-types/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "@crackle-fixtures/with-graphql-schema-types",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "author": "SEEK",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "dev": "crackle dev",
+    "fix": "crackle fix",
+    "package": "crackle package"
+  },
+  "dependencies": {
+    "@crackle-fixtures/graphql-schema": "link:./graphql-schema"
+  },
+  "devDpendencies": {}
+}

--- a/fixtures/with-graphql-schema-types/src/index.ts
+++ b/fixtures/with-graphql-schema-types/src/index.ts
@@ -1,0 +1,3 @@
+import type { Maybe } from '@crackle-fixtures/graphql-schema/types';
+
+export const maybe: Maybe<string> = null;

--- a/packages/core/src/package-utils/bundle.ts
+++ b/packages/core/src/package-utils/bundle.ts
@@ -70,7 +70,12 @@ export const createBundle = async (
 
   await viteBuild({
     ...commonViteConfig,
-    plugins: [addVanillaDebugIds(config), externals(config, 'esm'), react()],
+    plugins: [
+      addVanillaDebugIds(config),
+      // because we don't know ahead of time what the output format will be, we always patch imports
+      externals(config, 'esm'),
+      react(),
+    ],
     logLevel: 'warn',
     build: {
       outDir: config.root,

--- a/packages/core/src/package-utils/dts.ts
+++ b/packages/core/src/package-utils/dts.ts
@@ -13,7 +13,8 @@ export const createDtsBundle = async (
   const bundle = await rollup({
     input: entries.map((entry) => entry.entryPath),
     plugins: [
-      externals(config),
+      // patching imports is not needed for dts, as TypeScript can handle it (for now)
+      externals(config, 'cjs'),
       dts({
         respectExternal: true,
         compilerOptions: config.dtsOptions as any,

--- a/packages/core/src/plugins/rollup/externals.ts
+++ b/packages/core/src/plugins/rollup/externals.ts
@@ -85,10 +85,7 @@ async function findDependencies(options: ExternalsOptions) {
   return packagesById;
 }
 
-export function externals(
-  config: EnhancedConfig,
-  format: Format = 'esm',
-): Plugin {
+export function externals(config: EnhancedConfig, format?: Format): Plugin {
   const packageRoot = config.root;
   const packagePath = path.join(packageRoot, 'package.json');
   // eslint-disable-next-line no-sync

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -251,6 +251,12 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0(react@18.2.0)
 
+  fixtures/with-graphql-schema-types:
+    dependencies:
+      '@crackle-fixtures/graphql-schema':
+        specifier: link:./graphql-schema
+        version: link:graphql-schema
+
   fixtures/with-side-effects:
     dependencies:
       '@vanilla-extract/css':

--- a/tests/__snapshots__/package.test.ts.snap
+++ b/tests/__snapshots__/package.test.ts.snap
@@ -33,8 +33,8 @@ exports.render = render;
 
 exports[`package > fixture esm-patch-imports > dist/index.d.ts 1`] = `
 export { default as scopedSubpath } from '@crackle-fixtures/dep-with-exports/subpath';
-export { default as scopedPatchedSubpath } from '@crackle-fixtures/dep-with-exports-always-patch/index.js';
-export { default as cjsDirIndex } from 'autosuggest-highlight/parse/index.js';
+export { default as scopedPatchedSubpath } from '@crackle-fixtures/dep-with-exports-always-patch/subpath';
+export { default as cjsDirIndex } from 'autosuggest-highlight/parse';
 import React from 'react';
 
 declare const App: React.FC;
@@ -611,6 +611,28 @@ exports[`package > fixture with-flatten-children > dist/index.d.ts 1`] = `export
 exports[`package > fixture with-flatten-children > dist/index.mjs 1`] = `
 import flattenChildren from "react-keyed-flatten-children";
 flattenChildren([]);
+`;
+
+exports[`package > fixture with-graphql-schema-types > dist/index.cjs 1`] = `
+"use strict";
+Object.defineProperty(exports, Symbol.toStringTag, { value: "Module" });
+const maybe = null;
+exports.maybe = maybe;
+`;
+
+exports[`package > fixture with-graphql-schema-types > dist/index.d.ts 1`] = `
+import { Maybe } from '@crackle-fixtures/graphql-schema/types';
+
+declare const maybe: Maybe<string>;
+
+export { maybe };
+`;
+
+exports[`package > fixture with-graphql-schema-types > dist/index.mjs 1`] = `
+const maybe = null;
+export {
+  maybe
+};
 `;
 
 exports[`package > fixture with-side-effects > dist/Box.chunk.cjs 1`] = `

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -24,6 +24,7 @@ describe('package', () => {
     'single-entry-library',
     'with-dep-hidden-package-json',
     'with-flatten-children',
+    'with-graphql-schema-types',
     'with-side-effects',
   ])(
     'fixture %s',


### PR DESCRIPTION
TypeScript's resolution algorithm works like CJS, so it's fine for now.

This fixes an issue with packages that ship their types but don't have an `"exports"` key, so `resolve-from` errors out because it tries to resolve `package-name/types` to `package-name/types.ts`. Instead of reconciling, we'll let TypeScript resolve it.