### PR TITLE
Handle Vocab translation files

### DIFF
--- a/.changeset/healthy-cats-marry.md
+++ b/.changeset/healthy-cats-marry.md
@@ -1,0 +1,9 @@
+---
+'@crackle/core': minor
+---
+
+Handle Vocab translation files
+
+Crackle now produces an output that is compatible with the Vocab Webpack plugin.
+When packaging, Crackle will ensure that the `translation.json` files are present in the output directory, next to the generated translation files.
+This allows the Vocab plugin to still work with compiled (CJS/ESM) translation files.

--- a/.eslintignore
+++ b/.eslintignore
@@ -50,6 +50,12 @@ fixtures/with-side-effects/reset
 # end managed by crackle
 
 # managed by crackle
+fixtures/with-vocab/dist
+# end managed by crackle
+
+fixtures/with-vocab/**/*.vocab/index.ts
+
+# managed by crackle
 packages/babel-plugin-remove-exports/dist
 # end managed by crackle
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -53,6 +53,12 @@ fixtures/with-side-effects/reset
 # end managed by crackle
 
 # managed by crackle
+fixtures/with-vocab/dist
+# end managed by crackle
+
+fixtures/with-vocab/**/*.vocab/index.ts
+
+# managed by crackle
 packages/babel-plugin-remove-exports/dist
 # end managed by crackle
 

--- a/fixtures/esm-compat/src/.vocab/index.ts
+++ b/fixtures/esm-compat/src/.vocab/index.ts
@@ -1,1 +1,0 @@
-export default {};

--- a/fixtures/esm-compat/src/index.ts
+++ b/fixtures/esm-compat/src/index.ts
@@ -4,15 +4,7 @@ import cjsFauxEsm from 'react-keyed-flatten-children';
 import scopedSubpath from '@crackle-fixtures/dep-with-exports/subpath';
 import scopedPatchedSubpath from '@crackle-fixtures/dep-with-exports-always-patch/subpath';
 
-import translations from './.vocab';
-
 // imports must be exported otherwise they will be removed by Rollup
-export {
-  cjsFauxEsm,
-  cjsDirIndex,
-  scopedSubpath,
-  scopedPatchedSubpath,
-  translations,
-};
+export { cjsFauxEsm, cjsDirIndex, scopedSubpath, scopedPatchedSubpath };
 
 export { App, render } from './render';

--- a/fixtures/with-vocab/.gitignore
+++ b/fixtures/with-vocab/.gitignore
@@ -1,0 +1,5 @@
+# managed by crackle
+/dist
+# end managed by crackle
+
+**/*.vocab/index.ts

--- a/fixtures/with-vocab/package.json
+++ b/fixtures/with-vocab/package.json
@@ -6,9 +6,7 @@
   "author": "SEEK",
   "sideEffects": [
     "**/*.vocab/**",
-    "dist/index.*",
-    "dist/side-effects/**",
-    "src/client.tsx"
+    "dist/side-effects/**"
   ],
   "exports": {
     ".": {
@@ -38,7 +36,7 @@
   "devDependencies": {
     "@vocab/cli": "^1.3.3",
     "@vocab/react": "^1.1.5",
-    "@vocab/webpack": "^1.2.0",
+    "@vocab/webpack": "0.0.0-cjs-exports-20230421065519",
     "webpack": "^5.79.0",
     "webpack-cli": "^5.0.1"
   }

--- a/fixtures/with-vocab/package.json
+++ b/fixtures/with-vocab/package.json
@@ -36,7 +36,7 @@
   "devDependencies": {
     "@vocab/cli": "^1.3.3",
     "@vocab/react": "^1.1.5",
-    "@vocab/webpack": "0.0.0-cjs-exports-20230421065519",
+    "@vocab/webpack": "^1.2.1",
     "webpack": "^5.79.0",
     "webpack-cli": "^5.0.1"
   }

--- a/fixtures/with-vocab/package.json
+++ b/fixtures/with-vocab/package.json
@@ -1,0 +1,45 @@
+{
+  "name": "@crackle-fixtures/with-vocab",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "author": "SEEK",
+  "sideEffects": [
+    "**/*.vocab/**",
+    "dist/index.*",
+    "dist/side-effects/**",
+    "src/client.tsx"
+  ],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "compile": "vocab compile",
+    "dev": "crackle dev && pnpm compile",
+    "fix": "crackle fix",
+    "package": "pnpm compile && crackle package && webpack build"
+  },
+  "dependencies": {
+    "@vocab/core": "^1.3.0",
+    "react": "^18.2.0",
+    "react-dom": "^18.2.0"
+  },
+  "devDependencies": {
+    "@vocab/cli": "^1.3.3",
+    "@vocab/react": "^1.1.5",
+    "@vocab/webpack": "^1.2.0",
+    "webpack": "^5.79.0",
+    "webpack-cli": "^5.0.1"
+  }
+}

--- a/fixtures/with-vocab/src/.vocab/fr.translations.json
+++ b/fixtures/with-vocab/src/.vocab/fr.translations.json
@@ -1,0 +1,8 @@
+{
+  "hello": {
+    "message": "Bonjour"
+  },
+  "world": {
+    "message": "monde"
+  }
+}

--- a/fixtures/with-vocab/src/.vocab/translations.json
+++ b/fixtures/with-vocab/src/.vocab/translations.json
@@ -1,0 +1,8 @@
+{
+  "hello": {
+    "message": "Hello"
+  },
+  "world": {
+    "message": "world"
+  }
+}

--- a/fixtures/with-vocab/src/client.tsx
+++ b/fixtures/with-vocab/src/client.tsx
@@ -1,0 +1,75 @@
+import { VocabProvider, useTranslations } from '@vocab/react';
+import React, { type ReactNode, useState } from 'react';
+import { render } from 'react-dom';
+
+import commonTranslations from './.vocab';
+import clientTranslations from './client.vocab';
+
+function Content() {
+  const common = useTranslations(commonTranslations);
+  const client = useTranslations(clientTranslations);
+  const message = `${common.t('hello')} ${common.t('world')}`;
+  const specialCharacterResult = client.t(
+    'specialCharacters - \'‘’“”"!@#$%^&*()_+\\/`~\\\\',
+  );
+  const vocabPublishNode = client.t('vocabPublishDate', {
+    publishDate: 1605847714000,
+    strong: (children) => <strong>{children}</strong>,
+  });
+
+  return (
+    <>
+      <div id="message">{message}</div>
+      <div id="publish-date">{vocabPublishNode}</div>
+      <div id="special-characters">
+        Special Characters: {specialCharacterResult}
+      </div>
+    </>
+  );
+}
+
+function App({ children }: { children: ReactNode }) {
+  const [lang, setLang] = useState('en');
+  const [locale, setLocale] = useState('en-AU');
+
+  const theLocale = lang === 'en' ? locale : undefined;
+
+  return (
+    <VocabProvider language={lang} locale={theLocale}>
+      {children}
+      <label htmlFor="languages">Language:</label>
+      <select
+        name="languages"
+        id="language-select"
+        onChange={(event) => {
+          setLang(event.currentTarget.value);
+        }}
+      >
+        <option value="en">en</option>
+        <option value="fr">fr</option>
+        <option value="pseudo">pseudo</option>
+      </select>
+      {lang === 'en' ? (
+        <button
+          id="toggle-locale"
+          onClick={() =>
+            setLocale((curr) => (curr === 'en-AU' ? 'en-US' : 'en-AU'))
+          }
+        >
+          Toggle locale: {locale}
+        </button>
+      ) : null}
+    </VocabProvider>
+  );
+}
+
+const node = document.createElement('div');
+
+document.body.appendChild(node);
+
+render(
+  <App>
+    <Content />
+  </App>,
+  node,
+);

--- a/fixtures/with-vocab/src/client.tsx
+++ b/fixtures/with-vocab/src/client.tsx
@@ -4,8 +4,9 @@ import { render } from 'react-dom';
 
 import commonTranslations from './.vocab';
 import clientTranslations from './client.vocab';
+import { Content } from './components/Content';
 
-function Content() {
+function AllContent() {
   const common = useTranslations(commonTranslations);
   const client = useTranslations(clientTranslations);
   const message = `${common.t('hello')} ${common.t('world')}`;
@@ -70,6 +71,7 @@ export default () => {
 
   render(
     <App>
+      <AllContent />
       <Content />
     </App>,
     node,

--- a/fixtures/with-vocab/src/client.tsx
+++ b/fixtures/with-vocab/src/client.tsx
@@ -63,13 +63,15 @@ function App({ children }: { children: ReactNode }) {
   );
 }
 
-const node = document.createElement('div');
+export default () => {
+  const node = document.createElement('div');
 
-document.body.appendChild(node);
+  document.body.appendChild(node);
 
-render(
-  <App>
-    <Content />
-  </App>,
-  node,
-);
+  render(
+    <App>
+      <Content />
+    </App>,
+    node,
+  );
+};

--- a/fixtures/with-vocab/src/client.vocab/fr.translations.json
+++ b/fixtures/with-vocab/src/client.vocab/fr.translations.json
@@ -1,0 +1,8 @@
+{
+  "specialCharacters - '‘’“”\"!@#$%^&*()_+\\/`~\\\\": {
+    "message": "‘’“”'\"!@#$%^&*()_+\\/`~\\\\"
+  },
+  "vocabPublishDate": {
+    "message": "Vocab a été publié le {publishDate, date, medium}"
+  }
+}

--- a/fixtures/with-vocab/src/client.vocab/translations.json
+++ b/fixtures/with-vocab/src/client.vocab/translations.json
@@ -1,0 +1,8 @@
+{
+  "specialCharacters - '‘’“”\"!@#$%^&*()_+\\/`~\\\\": {
+    "message": "‘’“”'\"!@#$%^&*()_+\\/`~\\\\"
+  },
+  "vocabPublishDate": {
+    "message": "<strong>Vocab</strong> was published on {publishDate, date, small}"
+  }
+}

--- a/fixtures/with-vocab/src/components/Content.tsx
+++ b/fixtures/with-vocab/src/components/Content.tsx
@@ -1,0 +1,15 @@
+import { useTranslations } from '@vocab/react';
+import React from 'react';
+
+import commonTranslations from '../.vocab';
+
+export function Content() {
+  const common = useTranslations(commonTranslations);
+  const message = `${common.t('hello')} ${common.t('world')}`;
+
+  return (
+    <>
+      <div id="message">{message}</div>
+    </>
+  );
+}

--- a/fixtures/with-vocab/src/consumer.cts
+++ b/fixtures/with-vocab/src/consumer.cts
@@ -1,3 +1,4 @@
+// @ts-ignore compiled code
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const render = require('../dist/index.cjs');
 

--- a/fixtures/with-vocab/src/consumer.cts
+++ b/fixtures/with-vocab/src/consumer.cts
@@ -1,0 +1,4 @@
+// eslint-disable-next-line @typescript-eslint/no-var-requires
+const render = require('../dist/index.cjs');
+
+render();

--- a/fixtures/with-vocab/src/consumer.mts
+++ b/fixtures/with-vocab/src/consumer.mts
@@ -1,0 +1,3 @@
+import render from '../dist/index.mjs';
+
+render();

--- a/fixtures/with-vocab/src/consumer.mts
+++ b/fixtures/with-vocab/src/consumer.mts
@@ -1,3 +1,4 @@
+// @ts-ignore compiled code
 import render from '../dist/index.mjs';
 
 render();

--- a/fixtures/with-vocab/src/consumer.ts
+++ b/fixtures/with-vocab/src/consumer.ts
@@ -1,0 +1,1 @@
+import '../dist/index.mjs';

--- a/fixtures/with-vocab/src/consumer.ts
+++ b/fixtures/with-vocab/src/consumer.ts
@@ -1,1 +1,0 @@
-import '../dist/index.mjs';

--- a/fixtures/with-vocab/src/index.ts
+++ b/fixtures/with-vocab/src/index.ts
@@ -1,0 +1,1 @@
+import './client';

--- a/fixtures/with-vocab/src/index.ts
+++ b/fixtures/with-vocab/src/index.ts
@@ -1,1 +1,2 @@
-import './client';
+export * from './client';
+export { default } from './client';

--- a/fixtures/with-vocab/vocab.config.js
+++ b/fixtures/with-vocab/vocab.config.js
@@ -1,0 +1,4 @@
+module.exports = {
+  devLanguage: 'en',
+  languages: [{ name: 'en' }, { name: 'fr' }],
+};

--- a/fixtures/with-vocab/vocab.config.js
+++ b/fixtures/with-vocab/vocab.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  projectRoot: 'src',
   devLanguage: 'en',
   languages: [{ name: 'en' }, { name: 'fr' }],
 };

--- a/fixtures/with-vocab/webpack.config.js
+++ b/fixtures/with-vocab/webpack.config.js
@@ -1,9 +1,12 @@
 const { VocabWebpackPlugin } = require('@vocab/webpack');
 
 module.exports = {
-  entry: './src/consumer.ts',
+  entry: {
+    'with-mjs': './src/consumer.mts',
+    'with-cjs': './src/consumer.cts',
+  },
   mode: 'development',
-  devtool: 'source-map',
+  devtool: false,
   plugins: [
     new VocabWebpackPlugin({
       configFile: require.resolve('./vocab.config.js'),

--- a/fixtures/with-vocab/webpack.config.js
+++ b/fixtures/with-vocab/webpack.config.js
@@ -1,0 +1,12 @@
+const { VocabWebpackPlugin } = require('@vocab/webpack');
+
+module.exports = {
+  entry: './src/consumer.ts',
+  mode: 'development',
+  devtool: 'source-map',
+  plugins: [
+    new VocabWebpackPlugin({
+      configFile: require.resolve('./vocab.config.js'),
+    }),
+  ],
+};

--- a/package.json
+++ b/package.json
@@ -19,8 +19,8 @@
     "test": "pnpm test:unit:ci && pnpm test:integration:ci && pnpm test:playwright",
     "test:unit": "vitest",
     "test:unit:ci": "pnpm test:unit --run",
-    "test:integration": "vitest --config vitest.config.integration.ts",
-    "test:integration:ci": "pnpm test:integration --run",
+    "test:integration": "wireit",
+    "test:integration:ci": "pnpm test:integration -- --run",
     "test:playwright": "wireit",
     "test:braid": "pnpm fixtures:braid --test",
     "fixtures:add": "tsx ./scripts/add-fixture.ts",
@@ -117,6 +117,12 @@
       "dependencies": [
         "fixtures:dev",
         "./scripts:lint:tsc"
+      ]
+    },
+    "test:integration": {
+      "command": "vitest --config vitest.config.integration.ts",
+      "dependencies": [
+        "fixtures:dev"
       ]
     },
     "test:playwright": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -98,6 +98,7 @@
     "@vanilla-extract/integration": "^6.0.1",
     "@vanilla-extract/vite-plugin": "^3.7.0",
     "@vitejs/plugin-react": "^3.1.0",
+    "@vocab/webpack": "^1.2.0",
     "builtin-modules": "^3.3.0",
     "chalk": "^4.1.2",
     "dedent": "^0.7.0",

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -98,7 +98,7 @@
     "@vanilla-extract/integration": "^6.0.1",
     "@vanilla-extract/vite-plugin": "^3.7.0",
     "@vitejs/plugin-react": "^3.1.0",
-    "@vocab/webpack": "^1.2.0",
+    "@vocab/webpack": "^1.2.1",
     "builtin-modules": "^3.3.0",
     "chalk": "^4.1.2",
     "dedent": "^0.7.0",

--- a/packages/core/src/package-utils/bundle.ts
+++ b/packages/core/src/package-utils/bundle.ts
@@ -50,25 +50,25 @@ export const createBundle = async (
 
         // internal package resolved by plugins/vite/internal-package-resolution.ts
         if (srcPath.startsWith('../')) {
-          logger.debug(`Internal package ${srcPath}`);
+          logger.debug(`Internal package ${id}`);
           return;
         }
 
-        if (
-          isVanillaFile(id) ||
-          getModuleInfo(id)?.importers.some(isVanillaFile)
-        ) {
+        const moduleInfo = getModuleInfo(id)!;
+
+        if (isVanillaFile(id) || moduleInfo.importers.some(isVanillaFile)) {
           return normalizePath(`${stylesDir}/${srcPath}`);
         }
-        if (isVocabFile(id)) {
+        if (isVocabFile(moduleInfo.id)) {
+          logger.debug(`Vocab file ${id}`);
           return normalizePath(srcPath);
         }
         if (
           typeof packageJson.sideEffects !== 'undefined' &&
           moduleHasSideEffects(srcPath, packageJson.sideEffects) &&
-          !getModuleInfo(id)?.isEntry
+          !moduleInfo.isEntry
         ) {
-          logger.debug(`Has side-effects ${srcPath}`);
+          logger.debug(`Has side-effects ${id}`);
           return normalizePath(`${sideEffectsDir}/${srcPath}`);
         }
       },

--- a/packages/core/src/plugins/rollup/vocab-translations.ts
+++ b/packages/core/src/plugins/rollup/vocab-translations.ts
@@ -38,8 +38,11 @@ export const vocabTranslations = (
 
   resolveId: {
     order: 'pre',
-    async handler(id, importer) {
-      const resolved = (await this.resolve(id, importer, { skipSelf: true }))!;
+    async handler(id, importer, options) {
+      const resolved = (await this.resolve(id, importer, {
+        skipSelf: true,
+        ...options,
+      }))!;
       if (isVocabFile(resolved.id)) {
         const vocabDir = path.dirname(resolved.id);
         await handleVocabTranslations.call(this, vocabDir, toDistPath);

--- a/packages/core/src/plugins/rollup/vocab-translations.ts
+++ b/packages/core/src/plugins/rollup/vocab-translations.ts
@@ -2,19 +2,33 @@ import fs from 'fs/promises';
 import path from 'path';
 
 import { compiledVocabFileFilter } from '@vocab/webpack';
-import type { Plugin } from 'rollup';
+import type { Plugin, PluginContext } from 'rollup';
 
 import type { EnhancedConfig } from '../../config';
 import { memoize } from '../../utils/memoize';
 import { promiseMap } from '../../utils/promise-map';
 
-const getVocabDir = (id: string) => {
-  if (id.endsWith('.vocab')) return id;
-  if (id.endsWith('.vocab/index')) return path.dirname(id);
-};
+export const isVocabFile = (id: string) => compiledVocabFileFilter.test(id);
 
-export const isVocabFile = (id: string) =>
-  compiledVocabFileFilter.test(id) || Boolean(getVocabDir(id));
+const handleVocabTranslations = memoize(async function (
+  this: PluginContext,
+  vocabDir: string,
+  toDistPath: (id: string) => string,
+) {
+  const distDir = toDistPath(vocabDir);
+  await promiseMap(await fs.readdir(vocabDir), async (name) => {
+    if (name.endsWith('translations.json')) {
+      const json = await fs.readFile(path.join(vocabDir, name), 'utf-8');
+      this.emitFile({
+        type: 'asset',
+        fileName: path.join(distDir, name),
+        source: json,
+      });
+    }
+  });
+  // return value is important for memoize
+  return null;
+});
 
 export const vocabTranslations = (
   _config: EnhancedConfig,
@@ -24,27 +38,12 @@ export const vocabTranslations = (
 
   resolveId: {
     order: 'pre',
-    handler: memoize(async function (id, importer) {
-      const vocabDir = getVocabDir(id);
-      if (vocabDir) {
-        const translationsDir = path.resolve(path.dirname(importer!), vocabDir);
-        const distDir = toDistPath(translationsDir);
-        await promiseMap(await fs.readdir(translationsDir), async (name) => {
-          if (name.endsWith('translations.json')) {
-            const json = await fs.readFile(
-              path.join(translationsDir, name),
-              'utf-8',
-            );
-            this.emitFile({
-              type: 'asset',
-              fileName: path.join(distDir, name),
-              source: json,
-            });
-          }
-        });
+    async handler(id, importer) {
+      const resolved = (await this.resolve(id, importer, { skipSelf: true }))!;
+      if (isVocabFile(resolved.id)) {
+        const vocabDir = path.dirname(resolved.id);
+        await handleVocabTranslations.call(this, vocabDir, toDistPath);
       }
-      // return value is important for memoize
-      return null;
-    }),
+    },
   },
 });

--- a/packages/core/src/plugins/rollup/vocab-translations.ts
+++ b/packages/core/src/plugins/rollup/vocab-translations.ts
@@ -1,0 +1,50 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import { compiledVocabFileFilter } from '@vocab/webpack';
+import type { Plugin } from 'rollup';
+
+import type { EnhancedConfig } from '../../config';
+import { memoize } from '../../utils/memoize';
+import { promiseMap } from '../../utils/promise-map';
+
+const getVocabDir = (id: string) => {
+  if (id.endsWith('.vocab')) return id;
+  if (id.endsWith('.vocab/index')) return path.dirname(id);
+};
+
+export const isVocabFile = (id: string) =>
+  compiledVocabFileFilter.test(id) || Boolean(getVocabDir(id));
+
+export const vocabTranslations = (
+  _config: EnhancedConfig,
+  { toDistPath }: { toDistPath: (id: string) => string },
+): Plugin => ({
+  name: 'crackle:vocab-translations',
+
+  resolveId: {
+    order: 'pre',
+    handler: memoize(async function (id, importer) {
+      const vocabDir = getVocabDir(id);
+      if (vocabDir) {
+        const translationsDir = path.resolve(path.dirname(importer!), vocabDir);
+        const distDir = toDistPath(translationsDir);
+        await promiseMap(await fs.readdir(translationsDir), async (name) => {
+          if (name.endsWith('translations.json')) {
+            const json = await fs.readFile(
+              path.join(translationsDir, name),
+              'utf-8',
+            );
+            this.emitFile({
+              type: 'asset',
+              fileName: path.join(distDir, name),
+              source: json,
+            });
+          }
+        });
+      }
+      // return value is important for memoize
+      return null;
+    }),
+  },
+});

--- a/packages/core/src/plugins/rollup/vocab-translations.ts
+++ b/packages/core/src/plugins/rollup/vocab-translations.ts
@@ -10,6 +10,9 @@ import { promiseMap } from '../../utils/promise-map';
 
 export const isVocabFile = (id: string) => compiledVocabFileFilter.test(id);
 
+// Because this is called for every generated Vocab translation file, we don't want to emit assets
+// multiple times. The function is memoized so that it only emits assets once per `vocab` directory,
+// because the translation file can be imported from multiple places.
 const handleVocabTranslations = memoize(async function (
   this: PluginContext,
   vocabDir: string,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,8 +279,8 @@ importers:
         specifier: ^1.1.5
         version: 1.1.5(react@18.2.0)
       '@vocab/webpack':
-        specifier: 0.0.0-cjs-exports-20230421065519
-        version: 0.0.0-cjs-exports-20230421065519(webpack@5.79.0)
+        specifier: ^1.2.1
+        version: 1.2.1(webpack@5.79.0)
       webpack:
         specifier: ^5.79.0
         version: 5.79.0(webpack-cli@5.0.1)
@@ -362,8 +362,8 @@ importers:
         specifier: ^3.1.0
         version: 3.1.0(vite@4.3.0-beta.2)
       '@vocab/webpack':
-        specifier: ^1.2.0
-        version: 1.2.0
+        specifier: ^1.2.1
+        version: 1.2.1(webpack@5.79.0)
       builtin-modules:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1320,7 +1320,6 @@ packages:
   /@discoveryjs/json-ext@0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
-    dev: true
 
   /@emotion/hash@0.9.0:
     resolution: {integrity: sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==}
@@ -2111,7 +2110,6 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.17
-    dev: true
 
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
@@ -2379,18 +2377,15 @@ packages:
     dependencies:
       '@types/eslint': 8.37.0
       '@types/estree': 1.0.0
-    dev: true
 
   /@types/eslint@8.37.0:
     resolution: {integrity: sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==}
     dependencies:
       '@types/estree': 1.0.0
       '@types/json-schema': 7.0.11
-    dev: true
 
   /@types/estree@1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
-    dev: true
 
   /@types/express-serve-static-core@4.17.30:
     resolution: {integrity: sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==}
@@ -2969,8 +2964,8 @@ packages:
       - supports-color
     dev: true
 
-  /@vocab/webpack@0.0.0-cjs-exports-20230421065519(webpack@5.79.0):
-    resolution: {integrity: sha512-qNIZdjTsCq3kZ9dTg4nnFvBz7RWoJvp/64KrYIrkTc8AnYvsC1Q9GB2lELl0Ce9ySniQkhBcfeutVcEJPlyU1A==}
+  /@vocab/webpack@1.2.1(webpack@5.79.0):
+    resolution: {integrity: sha512-DVo6H3B+npwDEQUJ/VEeEoj9aojQLe9PPwSIFqxg2AJ/SC3zg2xba0UJ5n8YTmDj6vTFem8VrBfP/vJZ/nu7zQ==}
     peerDependencies:
       webpack: ^5.37.0
     dependencies:
@@ -2983,40 +2978,21 @@ packages:
       webpack: 5.79.0(webpack-cli@5.0.1)
     transitivePeerDependencies:
       - supports-color
-    dev: true
-
-  /@vocab/webpack@1.2.0:
-    resolution: {integrity: sha512-Ikyy7EVO4uUVvOvawd5ItCAuQm5+ZEHLYaNJcmlnnHl9Nani9ckRI7Db1qSr3I1vOsnU83wlHPfMtl3Gx1cUNw==}
-    peerDependencies:
-      webpack: ^5.37.0
-    dependencies:
-      '@vocab/core': 1.3.0
-      chalk: 4.1.2
-      debug: 4.3.4
-      es-module-lexer: 0.9.3
-      virtual-resource-loader: 1.0.1
-    transitivePeerDependencies:
-      - supports-color
-    dev: false
 
   /@webassemblyjs/ast@1.11.1:
     resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
     dependencies:
       '@webassemblyjs/helper-numbers': 1.11.1
       '@webassemblyjs/helper-wasm-bytecode': 1.11.1
-    dev: true
 
   /@webassemblyjs/floating-point-hex-parser@1.11.1:
     resolution: {integrity: sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==}
-    dev: true
 
   /@webassemblyjs/helper-api-error@1.11.1:
     resolution: {integrity: sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==}
-    dev: true
 
   /@webassemblyjs/helper-buffer@1.11.1:
     resolution: {integrity: sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==}
-    dev: true
 
   /@webassemblyjs/helper-numbers@1.11.1:
     resolution: {integrity: sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==}
@@ -3024,11 +3000,9 @@ packages:
       '@webassemblyjs/floating-point-hex-parser': 1.11.1
       '@webassemblyjs/helper-api-error': 1.11.1
       '@xtuc/long': 4.2.2
-    dev: true
 
   /@webassemblyjs/helper-wasm-bytecode@1.11.1:
     resolution: {integrity: sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==}
-    dev: true
 
   /@webassemblyjs/helper-wasm-section@1.11.1:
     resolution: {integrity: sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==}
@@ -3037,23 +3011,19 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.1
       '@webassemblyjs/helper-wasm-bytecode': 1.11.1
       '@webassemblyjs/wasm-gen': 1.11.1
-    dev: true
 
   /@webassemblyjs/ieee754@1.11.1:
     resolution: {integrity: sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==}
     dependencies:
       '@xtuc/ieee754': 1.2.0
-    dev: true
 
   /@webassemblyjs/leb128@1.11.1:
     resolution: {integrity: sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==}
     dependencies:
       '@xtuc/long': 4.2.2
-    dev: true
 
   /@webassemblyjs/utf8@1.11.1:
     resolution: {integrity: sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==}
-    dev: true
 
   /@webassemblyjs/wasm-edit@1.11.1:
     resolution: {integrity: sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==}
@@ -3066,7 +3036,6 @@ packages:
       '@webassemblyjs/wasm-opt': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
       '@webassemblyjs/wast-printer': 1.11.1
-    dev: true
 
   /@webassemblyjs/wasm-gen@1.11.1:
     resolution: {integrity: sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==}
@@ -3076,7 +3045,6 @@ packages:
       '@webassemblyjs/ieee754': 1.11.1
       '@webassemblyjs/leb128': 1.11.1
       '@webassemblyjs/utf8': 1.11.1
-    dev: true
 
   /@webassemblyjs/wasm-opt@1.11.1:
     resolution: {integrity: sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==}
@@ -3085,7 +3053,6 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.1
       '@webassemblyjs/wasm-gen': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
-    dev: true
 
   /@webassemblyjs/wasm-parser@1.11.1:
     resolution: {integrity: sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==}
@@ -3096,14 +3063,12 @@ packages:
       '@webassemblyjs/ieee754': 1.11.1
       '@webassemblyjs/leb128': 1.11.1
       '@webassemblyjs/utf8': 1.11.1
-    dev: true
 
   /@webassemblyjs/wast-printer@1.11.1:
     resolution: {integrity: sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==}
     dependencies:
       '@webassemblyjs/ast': 1.11.1
       '@xtuc/long': 4.2.2
-    dev: true
 
   /@webpack-cli/configtest@2.0.1(webpack-cli@5.0.1)(webpack@5.79.0):
     resolution: {integrity: sha512-njsdJXJSiS2iNbQVS0eT8A/KPnmyH4pv1APj2K0d1wrZcBLw+yppxOy4CGqa0OxDJkzfL/XELDhD8rocnIwB5A==}
@@ -3114,7 +3079,6 @@ packages:
     dependencies:
       webpack: 5.79.0(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack@5.79.0)
-    dev: true
 
   /@webpack-cli/info@2.0.1(webpack-cli@5.0.1)(webpack@5.79.0):
     resolution: {integrity: sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==}
@@ -3125,7 +3089,6 @@ packages:
     dependencies:
       webpack: 5.79.0(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack@5.79.0)
-    dev: true
 
   /@webpack-cli/serve@2.0.1(webpack-cli@5.0.1)(webpack@5.79.0):
     resolution: {integrity: sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==}
@@ -3140,15 +3103,12 @@ packages:
     dependencies:
       webpack: 5.79.0(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack@5.79.0)
-    dev: true
 
   /@xtuc/ieee754@1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
-    dev: true
 
   /@xtuc/long@4.2.2:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
-    dev: true
 
   /accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -3164,7 +3124,6 @@ packages:
       acorn: ^8
     dependencies:
       acorn: 8.8.2
-    dev: true
 
   /acorn-jsx@5.3.2(acorn@8.8.2):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3194,7 +3153,6 @@ packages:
       ajv: ^6.9.1
     dependencies:
       ajv: 6.12.6
-    dev: true
 
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -3688,7 +3646,6 @@ packages:
   /chrome-trace-event@1.0.3:
     resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
     engines: {node: '>=6.0'}
-    dev: true
 
   /ci-info@2.0.0:
     resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
@@ -3700,7 +3657,6 @@ packages:
 
   /cjs-module-lexer@1.2.2:
     resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
-    dev: true
 
   /cli-boxes@2.2.1:
     resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}
@@ -3761,7 +3717,6 @@ packages:
       is-plain-object: 2.0.4
       kind-of: 6.0.3
       shallow-clone: 3.0.1
-    dev: true
 
   /clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -3803,7 +3758,6 @@ packages:
 
   /colorette@2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
-    dev: true
 
   /combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -3813,12 +3767,10 @@ packages:
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
-    dev: true
 
   /commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
-    dev: true
 
   /commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -4194,7 +4146,6 @@ packages:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
     engines: {node: '>=4'}
     hasBin: true
-    dev: true
 
   /error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -4942,7 +4893,6 @@ packages:
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
-    dev: true
 
   /execa@1.0.0:
     resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
@@ -5078,7 +5028,6 @@ packages:
   /fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
-    dev: true
 
   /fastest-validator@1.16.0:
     resolution: {integrity: sha512-+C1cFoLboOZIZs2PWhceNtJ15zCoiRalu1LnJB4hy63Y8Tto9bkqGcTGkzegt+Xu4qy3LE9GL6CLzEdpZ5xJBQ==}
@@ -5651,7 +5600,6 @@ packages:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
-    dev: true
 
   /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -5736,7 +5684,6 @@ packages:
   /interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
-    dev: true
 
   /intl-messageformat@10.3.3:
     resolution: {integrity: sha512-un/f07/g2e/3Q8e1ghDKET+el22Bi49M7O/rHxd597R+oLpPOMykSv5s51cABVfu3FZW+fea4hrzf2MHu1W4hw==}
@@ -5922,7 +5869,6 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       isobject: 3.0.1
-    dev: true
 
   /is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
@@ -6012,7 +5958,6 @@ packages:
   /isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
-    dev: true
 
   /isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -6159,7 +6104,6 @@ packages:
       '@types/node': 18.11.17
       merge-stream: 2.0.0
       supports-color: 8.1.1
-    dev: true
 
   /jest-worker@29.0.2:
     resolution: {integrity: sha512-EyvBlYcvd2pg28yg5A3OODQnqK9LI1kitnGUZUG5/NYIeaRgewtYBKB5wlr7oXj8zPCkzev7EmnTCsrXK7V+Xw==}
@@ -6324,7 +6268,6 @@ packages:
   /loader-runner@4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
-    dev: true
 
   /loader-utils@2.0.4:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
@@ -6671,7 +6614,6 @@ packages:
 
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
-    dev: true
 
   /nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -7504,7 +7446,6 @@ packages:
     engines: {node: '>= 10.13.0'}
     dependencies:
       resolve: 1.22.1
-    dev: true
 
   /redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -7586,7 +7527,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       resolve-from: 5.0.0
-    dev: true
 
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -7724,7 +7664,6 @@ packages:
       '@types/json-schema': 7.0.11
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
-    dev: true
 
   /scule@1.0.0:
     resolution: {integrity: sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==}
@@ -7777,7 +7716,6 @@ packages:
     resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
     dependencies:
       randombytes: 2.1.0
-    dev: true
 
   /serve-handler@6.1.5:
     resolution: {integrity: sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==}
@@ -7816,7 +7754,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       kind-of: 6.0.3
-    dev: true
 
   /shebang-command@1.2.0:
     resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
@@ -8211,7 +8148,6 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.16.9
       webpack: 5.79.0(webpack-cli@5.0.1)
-    dev: true
 
   /terser@5.16.9:
     resolution: {integrity: sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==}
@@ -8222,7 +8158,6 @@ packages:
       acorn: 8.8.2
       commander: 2.20.3
       source-map-support: 0.5.21
-    dev: true
 
   /test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -8785,7 +8720,6 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.10
-    dev: true
 
   /wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
@@ -8827,7 +8761,6 @@ packages:
       rechoir: 0.8.0
       webpack: 5.79.0(webpack-cli@5.0.1)
       webpack-merge: 5.8.0
-    dev: true
 
   /webpack-merge@5.8.0:
     resolution: {integrity: sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==}
@@ -8835,12 +8768,10 @@ packages:
     dependencies:
       clone-deep: 4.0.1
       wildcard: 2.0.0
-    dev: true
 
   /webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
-    dev: true
 
   /webpack@5.79.0(webpack-cli@5.0.1):
     resolution: {integrity: sha512-3mN4rR2Xq+INd6NnYuL9RC9GAmc1ROPKJoHhrZ4pAjdMFEkJJWrsPw8o2JjCIyQyTu7rTXYn4VG6OpyB3CobZg==}
@@ -8881,7 +8812,6 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
-    dev: true
 
   /well-known-symbols@2.0.0:
     resolution: {integrity: sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==}
@@ -8958,7 +8888,6 @@ packages:
 
   /wildcard@2.0.0:
     resolution: {integrity: sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==}
-    dev: true
 
   /wireit@0.9.5:
     resolution: {integrity: sha512-dKKNAwLxQjbPPMrltPxMUFKvLy2z6hlVjvR/qitvPm8GEQyb/1QYBG7ObvOQLsi95uAXpkWLJXBYkCKeVcMVgA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -279,8 +279,8 @@ importers:
         specifier: ^1.1.5
         version: 1.1.5(react@18.2.0)
       '@vocab/webpack':
-        specifier: ^1.2.0
-        version: 1.2.0(webpack@5.79.0)
+        specifier: 0.0.0-cjs-exports-20230421065519
+        version: 0.0.0-cjs-exports-20230421065519(webpack@5.79.0)
       webpack:
         specifier: ^5.79.0
         version: 5.79.0(webpack-cli@5.0.1)
@@ -363,7 +363,7 @@ importers:
         version: 3.1.0(vite@4.3.0-beta.2)
       '@vocab/webpack':
         specifier: ^1.2.0
-        version: 1.2.0(webpack@5.79.0)
+        version: 1.2.0
       builtin-modules:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1320,6 +1320,7 @@ packages:
   /@discoveryjs/json-ext@0.5.7:
     resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
     engines: {node: '>=10.0.0'}
+    dev: true
 
   /@emotion/hash@0.9.0:
     resolution: {integrity: sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==}
@@ -2110,6 +2111,7 @@ packages:
     dependencies:
       '@jridgewell/gen-mapping': 0.3.2
       '@jridgewell/trace-mapping': 0.3.17
+    dev: true
 
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
@@ -2377,15 +2379,18 @@ packages:
     dependencies:
       '@types/eslint': 8.37.0
       '@types/estree': 1.0.0
+    dev: true
 
   /@types/eslint@8.37.0:
     resolution: {integrity: sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==}
     dependencies:
       '@types/estree': 1.0.0
       '@types/json-schema': 7.0.11
+    dev: true
 
   /@types/estree@1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
+    dev: true
 
   /@types/express-serve-static-core@4.17.30:
     resolution: {integrity: sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==}
@@ -2964,7 +2969,23 @@ packages:
       - supports-color
     dev: true
 
-  /@vocab/webpack@1.2.0(webpack@5.79.0):
+  /@vocab/webpack@0.0.0-cjs-exports-20230421065519(webpack@5.79.0):
+    resolution: {integrity: sha512-qNIZdjTsCq3kZ9dTg4nnFvBz7RWoJvp/64KrYIrkTc8AnYvsC1Q9GB2lELl0Ce9ySniQkhBcfeutVcEJPlyU1A==}
+    peerDependencies:
+      webpack: ^5.37.0
+    dependencies:
+      '@vocab/core': 1.3.0
+      chalk: 4.1.2
+      cjs-module-lexer: 1.2.2
+      debug: 4.3.4
+      es-module-lexer: 0.9.3
+      virtual-resource-loader: 1.0.1
+      webpack: 5.79.0(webpack-cli@5.0.1)
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@vocab/webpack@1.2.0:
     resolution: {integrity: sha512-Ikyy7EVO4uUVvOvawd5ItCAuQm5+ZEHLYaNJcmlnnHl9Nani9ckRI7Db1qSr3I1vOsnU83wlHPfMtl3Gx1cUNw==}
     peerDependencies:
       webpack: ^5.37.0
@@ -2974,24 +2995,28 @@ packages:
       debug: 4.3.4
       es-module-lexer: 0.9.3
       virtual-resource-loader: 1.0.1
-      webpack: 5.79.0(webpack-cli@5.0.1)
     transitivePeerDependencies:
       - supports-color
+    dev: false
 
   /@webassemblyjs/ast@1.11.1:
     resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
     dependencies:
       '@webassemblyjs/helper-numbers': 1.11.1
       '@webassemblyjs/helper-wasm-bytecode': 1.11.1
+    dev: true
 
   /@webassemblyjs/floating-point-hex-parser@1.11.1:
     resolution: {integrity: sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==}
+    dev: true
 
   /@webassemblyjs/helper-api-error@1.11.1:
     resolution: {integrity: sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==}
+    dev: true
 
   /@webassemblyjs/helper-buffer@1.11.1:
     resolution: {integrity: sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==}
+    dev: true
 
   /@webassemblyjs/helper-numbers@1.11.1:
     resolution: {integrity: sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==}
@@ -2999,9 +3024,11 @@ packages:
       '@webassemblyjs/floating-point-hex-parser': 1.11.1
       '@webassemblyjs/helper-api-error': 1.11.1
       '@xtuc/long': 4.2.2
+    dev: true
 
   /@webassemblyjs/helper-wasm-bytecode@1.11.1:
     resolution: {integrity: sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==}
+    dev: true
 
   /@webassemblyjs/helper-wasm-section@1.11.1:
     resolution: {integrity: sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==}
@@ -3010,19 +3037,23 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.1
       '@webassemblyjs/helper-wasm-bytecode': 1.11.1
       '@webassemblyjs/wasm-gen': 1.11.1
+    dev: true
 
   /@webassemblyjs/ieee754@1.11.1:
     resolution: {integrity: sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==}
     dependencies:
       '@xtuc/ieee754': 1.2.0
+    dev: true
 
   /@webassemblyjs/leb128@1.11.1:
     resolution: {integrity: sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==}
     dependencies:
       '@xtuc/long': 4.2.2
+    dev: true
 
   /@webassemblyjs/utf8@1.11.1:
     resolution: {integrity: sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==}
+    dev: true
 
   /@webassemblyjs/wasm-edit@1.11.1:
     resolution: {integrity: sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==}
@@ -3035,6 +3066,7 @@ packages:
       '@webassemblyjs/wasm-opt': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
       '@webassemblyjs/wast-printer': 1.11.1
+    dev: true
 
   /@webassemblyjs/wasm-gen@1.11.1:
     resolution: {integrity: sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==}
@@ -3044,6 +3076,7 @@ packages:
       '@webassemblyjs/ieee754': 1.11.1
       '@webassemblyjs/leb128': 1.11.1
       '@webassemblyjs/utf8': 1.11.1
+    dev: true
 
   /@webassemblyjs/wasm-opt@1.11.1:
     resolution: {integrity: sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==}
@@ -3052,6 +3085,7 @@ packages:
       '@webassemblyjs/helper-buffer': 1.11.1
       '@webassemblyjs/wasm-gen': 1.11.1
       '@webassemblyjs/wasm-parser': 1.11.1
+    dev: true
 
   /@webassemblyjs/wasm-parser@1.11.1:
     resolution: {integrity: sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==}
@@ -3062,12 +3096,14 @@ packages:
       '@webassemblyjs/ieee754': 1.11.1
       '@webassemblyjs/leb128': 1.11.1
       '@webassemblyjs/utf8': 1.11.1
+    dev: true
 
   /@webassemblyjs/wast-printer@1.11.1:
     resolution: {integrity: sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==}
     dependencies:
       '@webassemblyjs/ast': 1.11.1
       '@xtuc/long': 4.2.2
+    dev: true
 
   /@webpack-cli/configtest@2.0.1(webpack-cli@5.0.1)(webpack@5.79.0):
     resolution: {integrity: sha512-njsdJXJSiS2iNbQVS0eT8A/KPnmyH4pv1APj2K0d1wrZcBLw+yppxOy4CGqa0OxDJkzfL/XELDhD8rocnIwB5A==}
@@ -3078,6 +3114,7 @@ packages:
     dependencies:
       webpack: 5.79.0(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack@5.79.0)
+    dev: true
 
   /@webpack-cli/info@2.0.1(webpack-cli@5.0.1)(webpack@5.79.0):
     resolution: {integrity: sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==}
@@ -3088,6 +3125,7 @@ packages:
     dependencies:
       webpack: 5.79.0(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack@5.79.0)
+    dev: true
 
   /@webpack-cli/serve@2.0.1(webpack-cli@5.0.1)(webpack@5.79.0):
     resolution: {integrity: sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==}
@@ -3102,12 +3140,15 @@ packages:
     dependencies:
       webpack: 5.79.0(webpack-cli@5.0.1)
       webpack-cli: 5.0.1(webpack@5.79.0)
+    dev: true
 
   /@xtuc/ieee754@1.2.0:
     resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
+    dev: true
 
   /@xtuc/long@4.2.2:
     resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+    dev: true
 
   /accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
@@ -3123,6 +3164,7 @@ packages:
       acorn: ^8
     dependencies:
       acorn: 8.8.2
+    dev: true
 
   /acorn-jsx@5.3.2(acorn@8.8.2):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3152,6 +3194,7 @@ packages:
       ajv: ^6.9.1
     dependencies:
       ajv: 6.12.6
+    dev: true
 
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -3645,6 +3688,7 @@ packages:
   /chrome-trace-event@1.0.3:
     resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
     engines: {node: '>=6.0'}
+    dev: true
 
   /ci-info@2.0.0:
     resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
@@ -3653,6 +3697,10 @@ packages:
   /ci-info@3.3.2:
     resolution: {integrity: sha512-xmDt/QIAdeZ9+nfdPsaBCpMvHNLFiLdjj59qjqn+6iPe6YmHGQ35sBnQ8uslRBXFmXkiZQOJRjvQeoGppoTjjg==}
     dev: false
+
+  /cjs-module-lexer@1.2.2:
+    resolution: {integrity: sha512-cOU9usZw8/dXIXKtwa8pM0OTJQuJkxMN6w30csNRUerHfeQ5R6U3kkU/FtJeIf3M202OHfY2U8ccInBG7/xogA==}
+    dev: true
 
   /cli-boxes@2.2.1:
     resolution: {integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==}
@@ -3713,6 +3761,7 @@ packages:
       is-plain-object: 2.0.4
       kind-of: 6.0.3
       shallow-clone: 3.0.1
+    dev: true
 
   /clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -3754,6 +3803,7 @@ packages:
 
   /colorette@2.0.19:
     resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
+    dev: true
 
   /combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
@@ -3763,10 +3813,12 @@ packages:
 
   /commander@2.20.3:
     resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+    dev: true
 
   /commander@9.5.0:
     resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
     engines: {node: ^12.20.0 || >=14}
+    dev: true
 
   /commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -4142,6 +4194,7 @@ packages:
     resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
     engines: {node: '>=4'}
     hasBin: true
+    dev: true
 
   /error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -4889,6 +4942,7 @@ packages:
   /events@3.3.0:
     resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
     engines: {node: '>=0.8.x'}
+    dev: true
 
   /execa@1.0.0:
     resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
@@ -5024,6 +5078,7 @@ packages:
   /fastest-levenshtein@1.0.16:
     resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
     engines: {node: '>= 4.9.1'}
+    dev: true
 
   /fastest-validator@1.16.0:
     resolution: {integrity: sha512-+C1cFoLboOZIZs2PWhceNtJ15zCoiRalu1LnJB4hy63Y8Tto9bkqGcTGkzegt+Xu4qy3LE9GL6CLzEdpZ5xJBQ==}
@@ -5596,6 +5651,7 @@ packages:
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
+    dev: true
 
   /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -5680,6 +5736,7 @@ packages:
   /interpret@3.1.1:
     resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
     engines: {node: '>=10.13.0'}
+    dev: true
 
   /intl-messageformat@10.3.3:
     resolution: {integrity: sha512-un/f07/g2e/3Q8e1ghDKET+el22Bi49M7O/rHxd597R+oLpPOMykSv5s51cABVfu3FZW+fea4hrzf2MHu1W4hw==}
@@ -5865,6 +5922,7 @@ packages:
     engines: {node: '>=0.10.0'}
     dependencies:
       isobject: 3.0.1
+    dev: true
 
   /is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
@@ -5954,6 +6012,7 @@ packages:
   /isobject@3.0.1:
     resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
     engines: {node: '>=0.10.0'}
+    dev: true
 
   /isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
@@ -6100,6 +6159,7 @@ packages:
       '@types/node': 18.11.17
       merge-stream: 2.0.0
       supports-color: 8.1.1
+    dev: true
 
   /jest-worker@29.0.2:
     resolution: {integrity: sha512-EyvBlYcvd2pg28yg5A3OODQnqK9LI1kitnGUZUG5/NYIeaRgewtYBKB5wlr7oXj8zPCkzev7EmnTCsrXK7V+Xw==}
@@ -6264,6 +6324,7 @@ packages:
   /loader-runner@4.3.0:
     resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
     engines: {node: '>=6.11.5'}
+    dev: true
 
   /loader-utils@2.0.4:
     resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
@@ -6610,6 +6671,7 @@ packages:
 
   /neo-async@2.6.2:
     resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+    dev: true
 
   /nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
@@ -7442,6 +7504,7 @@ packages:
     engines: {node: '>= 10.13.0'}
     dependencies:
       resolve: 1.22.1
+    dev: true
 
   /redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -7523,6 +7586,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       resolve-from: 5.0.0
+    dev: true
 
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
@@ -7660,6 +7724,7 @@ packages:
       '@types/json-schema': 7.0.11
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
+    dev: true
 
   /scule@1.0.0:
     resolution: {integrity: sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==}
@@ -7712,6 +7777,7 @@ packages:
     resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
     dependencies:
       randombytes: 2.1.0
+    dev: true
 
   /serve-handler@6.1.5:
     resolution: {integrity: sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==}
@@ -7750,6 +7816,7 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       kind-of: 6.0.3
+    dev: true
 
   /shebang-command@1.2.0:
     resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
@@ -8144,6 +8211,7 @@ packages:
       serialize-javascript: 6.0.1
       terser: 5.16.9
       webpack: 5.79.0(webpack-cli@5.0.1)
+    dev: true
 
   /terser@5.16.9:
     resolution: {integrity: sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==}
@@ -8154,6 +8222,7 @@ packages:
       acorn: 8.8.2
       commander: 2.20.3
       source-map-support: 0.5.21
+    dev: true
 
   /test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -8716,6 +8785,7 @@ packages:
     dependencies:
       glob-to-regexp: 0.4.1
       graceful-fs: 4.2.10
+    dev: true
 
   /wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
@@ -8757,6 +8827,7 @@ packages:
       rechoir: 0.8.0
       webpack: 5.79.0(webpack-cli@5.0.1)
       webpack-merge: 5.8.0
+    dev: true
 
   /webpack-merge@5.8.0:
     resolution: {integrity: sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==}
@@ -8764,10 +8835,12 @@ packages:
     dependencies:
       clone-deep: 4.0.1
       wildcard: 2.0.0
+    dev: true
 
   /webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
+    dev: true
 
   /webpack@5.79.0(webpack-cli@5.0.1):
     resolution: {integrity: sha512-3mN4rR2Xq+INd6NnYuL9RC9GAmc1ROPKJoHhrZ4pAjdMFEkJJWrsPw8o2JjCIyQyTu7rTXYn4VG6OpyB3CobZg==}
@@ -8808,6 +8881,7 @@ packages:
       - '@swc/core'
       - esbuild
       - uglify-js
+    dev: true
 
   /well-known-symbols@2.0.0:
     resolution: {integrity: sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==}
@@ -8884,6 +8958,7 @@ packages:
 
   /wildcard@2.0.0:
     resolution: {integrity: sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==}
+    dev: true
 
   /wireit@0.9.5:
     resolution: {integrity: sha512-dKKNAwLxQjbPPMrltPxMUFKvLy2z6hlVjvR/qitvPm8GEQyb/1QYBG7ObvOQLsi95uAXpkWLJXBYkCKeVcMVgA==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,34 @@ importers:
         specifier: ^1.5.1
         version: 1.5.2(@vanilla-extract/css@1.9.2)
 
+  fixtures/with-vocab:
+    dependencies:
+      '@vocab/core':
+        specifier: ^1.3.0
+        version: 1.3.0
+      react:
+        specifier: ^18.2.0
+        version: 18.2.0
+      react-dom:
+        specifier: ^18.2.0
+        version: 18.2.0(react@18.2.0)
+    devDependencies:
+      '@vocab/cli':
+        specifier: ^1.3.3
+        version: 1.3.3
+      '@vocab/react':
+        specifier: ^1.1.5
+        version: 1.1.5(react@18.2.0)
+      '@vocab/webpack':
+        specifier: ^1.2.0
+        version: 1.2.0(webpack@5.79.0)
+      webpack:
+        specifier: ^5.79.0
+        version: 5.79.0(webpack-cli@5.0.1)
+      webpack-cli:
+        specifier: ^5.0.1
+        version: 5.0.1(webpack@5.79.0)
+
   packages/babel-plugin-remove-exports:
     dependencies:
       '@babel/core':
@@ -333,6 +361,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^3.1.0
         version: 3.1.0(vite@4.3.0-beta.2)
+      '@vocab/webpack':
+        specifier: ^1.2.0
+        version: 1.2.0(webpack@5.79.0)
       builtin-modules:
         specifier: ^3.3.0
         version: 3.3.0
@@ -1286,6 +1317,10 @@ packages:
       - react-dom
     dev: false
 
+  /@discoveryjs/json-ext@0.5.7:
+    resolution: {integrity: sha512-dBVuXR082gk3jsFp7Rd/JI4kytwGHecnCoTtXFb7DB6CNHp4rg5k1bhg0nWdLGLnOV71lmDzGQaLMy8iPLY0pw==}
+    engines: {node: '>=10.0.0'}
+
   /@emotion/hash@0.9.0:
     resolution: {integrity: sha512-14FtKiHhy2QoPIzdTcvh//8OyBlknNs2nXRwIhG904opCby3l+9Xaf/wuPvICBF0rc1ZCNBd3nKe9cd2mecVkQ==}
     dev: false
@@ -1933,6 +1968,35 @@ packages:
       - supports-color
     dev: false
 
+  /@formatjs/ecma402-abstract@1.14.3:
+    resolution: {integrity: sha512-SlsbRC/RX+/zg4AApWIFNDdkLtFbkq3LNoZWXZCE/nHVKqoIJyaoQyge/I0Y38vLxowUn9KTtXgusLD91+orbg==}
+    dependencies:
+      '@formatjs/intl-localematcher': 0.2.32
+      tslib: 2.4.0
+
+  /@formatjs/fast-memoize@2.0.1:
+    resolution: {integrity: sha512-M2GgV+qJn5WJQAYewz7q2Cdl6fobQa69S1AzSM2y0P68ZDbK5cWrJIcPCO395Of1ksftGZoOt4LYCO/j9BKBSA==}
+    dependencies:
+      tslib: 2.4.0
+
+  /@formatjs/icu-messageformat-parser@2.3.0:
+    resolution: {integrity: sha512-xqtlqYAbfJDF4b6e4O828LBNOWXrFcuYadqAbYORlDRwhyJ2bH+xpUBPldZbzRGUN2mxlZ4Ykhm7jvERtmI8NQ==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.14.3
+      '@formatjs/icu-skeleton-parser': 1.3.18
+      tslib: 2.4.0
+
+  /@formatjs/icu-skeleton-parser@1.3.18:
+    resolution: {integrity: sha512-ND1ZkZfmLPcHjAH1sVpkpQxA+QYfOX3py3SjKWMUVGDow18gZ0WPqz3F+pJLYQMpS2LnnQ5zYR2jPVYTbRwMpg==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.14.3
+      tslib: 2.4.0
+
+  /@formatjs/intl-localematcher@0.2.32:
+    resolution: {integrity: sha512-k/MEBstff4sttohyEpXxCmC3MqbUn9VvHGlZ8fauLzkbwXmVrEeyzS+4uhrvAk9DWU9/7otYWxyDox4nT/KVLQ==}
+    dependencies:
+      tslib: 2.4.0
+
   /@humanwhocodes/config-array@0.10.7:
     resolution: {integrity: sha512-MDl6D6sBsaV452/QSdX+4CXIjZhIcI0PELsxUjk4U828yd58vk3bTIvk/6w5FY+4hIy9sLW0sfrV7K7Kc++j/w==}
     engines: {node: '>=10.10.0'}
@@ -2040,6 +2104,12 @@ packages:
   /@jridgewell/set-array@1.1.2:
     resolution: {integrity: sha512-xnkseuNADM0gt2bs+BvhO0p78Mk762YnZdsuzFV018NoG1Sj1SCQvpSqa7XUaTam5vAGasABV9qXASMKnFMwMw==}
     engines: {node: '>=6.0.0'}
+
+  /@jridgewell/source-map@0.3.3:
+    resolution: {integrity: sha512-b+fsZXeLYi9fEULmfBrhxn4IrPlINf8fiNarzTof004v3lFdntdwa9PF7vFJqm3mg7s+ScJMxXaE3Acp1irZcg==}
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.2
+      '@jridgewell/trace-mapping': 0.3.17
 
   /@jridgewell/sourcemap-codec@1.4.14:
     resolution: {integrity: sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==}
@@ -2298,9 +2368,24 @@ packages:
   /@types/dedent@0.7.0:
     resolution: {integrity: sha512-EGlKlgMhnLt/cM4DbUSafFdrkeJoC9Mvnj0PUCU7tFmTjMjNRT957kXCx0wYm3JuEq4o4ZsS5vG+NlkM2DMd2A==}
 
+  /@types/env-ci@3.1.1:
+    resolution: {integrity: sha512-JuX+LHsvhktApmZxmBrG458kfSvPAvs2Kqhyrow3IKtDsbcRco7NFgpsNthjp8EQxKA6PMw3DrY/IH8ZAuTYlQ==}
+    dev: true
+
+  /@types/eslint-scope@3.7.4:
+    resolution: {integrity: sha512-9K4zoImiZc3HlIp6AVUDE4CWYx22a+lhSZMYNpbjW04+YF0KWj4pJXnEMjdnFTiQibFFmElcsasJXDbdI/EPhA==}
+    dependencies:
+      '@types/eslint': 8.37.0
+      '@types/estree': 1.0.0
+
+  /@types/eslint@8.37.0:
+    resolution: {integrity: sha512-Piet7dG2JBuDIfohBngQ3rCt7MgO9xCO4xIMKxBThCq5PNRB91IjlJ10eJVwfoNtvTErmxLzwBZ7rHZtbOMmFQ==}
+    dependencies:
+      '@types/estree': 1.0.0
+      '@types/json-schema': 7.0.11
+
   /@types/estree@1.0.0:
     resolution: {integrity: sha512-WulqXMDUTYAXCjZnk6JtIHPigp55cVtDgDrO2gHRwhyJto21+1zbVCtOYB2L1F9w4qCQ0rOGWBnBe0FNTiEJIQ==}
-    dev: true
 
   /@types/express-serve-static-core@4.17.30:
     resolution: {integrity: sha512-gstzbTWro2/nFed1WXtf+TtrpwxH7Ggs4RLYTLbeVgIkUQOI3WG/JKjgeOU1zXDvezllupjrf8OPIdvTbIaVOQ==}
@@ -2366,7 +2451,6 @@ packages:
 
   /@types/json-schema@7.0.11:
     resolution: {integrity: sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==}
-    dev: false
 
   /@types/json5@0.0.29:
     resolution: {integrity: sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==}
@@ -2821,6 +2905,210 @@ packages:
       pretty-format: 27.5.1
     dev: false
 
+  /@vocab/cli@1.3.3:
+    resolution: {integrity: sha512-x6iXs00ZYI6NWo4/OAFvkMUEScc1bN5Lble9kXG8Vw3Glu27bglkTmHC+fGGupnX2HFgzup7U3K63wFiUy6mPw==}
+    hasBin: true
+    dependencies:
+      '@types/env-ci': 3.1.1
+      '@vocab/core': 1.3.0
+      '@vocab/phrase': 1.2.4
+      env-ci: 5.5.0
+      fast-glob: 3.2.12
+      form-data: 3.0.1
+      node-fetch: 2.6.7
+      prettier: 2.8.6
+      yargs: 16.2.0
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
+  /@vocab/core@1.3.0:
+    resolution: {integrity: sha512-WqZpUZ5u03yM5xnXwbmItWaA/StaA52J24eTMtIIia6ggHDHrxkHxK2VN5CWYWya3FqVDWSbfK1AuzUevPEm+A==}
+    dependencies:
+      '@formatjs/icu-messageformat-parser': 2.3.0
+      chalk: 4.1.2
+      chokidar: 3.5.3
+      debug: 4.3.4
+      fast-glob: 3.2.12
+      fastest-validator: 1.16.0
+      find-up: 5.0.0
+      intl-messageformat: 10.3.3
+      prettier: 2.8.6
+    transitivePeerDependencies:
+      - supports-color
+
+  /@vocab/phrase@1.2.4:
+    resolution: {integrity: sha512-FU7XMEfW4H6Ji3tvqWwvaEuYD6RSgIpvOYKyuoK+f2FeCCawi9N9IJ2XP4qoAMPb0tGcDNSqLKGquJn0UD6dtA==}
+    dependencies:
+      '@vocab/core': 1.3.0
+      chalk: 4.1.2
+      csv-stringify: 6.3.0
+      debug: 4.3.4
+      form-data: 3.0.1
+      node-fetch: 2.6.7
+    transitivePeerDependencies:
+      - encoding
+      - supports-color
+    dev: true
+
+  /@vocab/react@1.1.5(react@18.2.0):
+    resolution: {integrity: sha512-fHddDJvucTOOIY3n81bX7ddgJCkc2PoEAmFMP3iOOjcE1ND1jYMHAWwBE+nU0jwkAZdYW2ZrpiSubOd4ThMaEw==}
+    peerDependencies:
+      react: '>=16.3.0'
+    dependencies:
+      '@vocab/core': 1.3.0
+      intl-messageformat: 10.3.3
+      react: 18.2.0
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
+  /@vocab/webpack@1.2.0(webpack@5.79.0):
+    resolution: {integrity: sha512-Ikyy7EVO4uUVvOvawd5ItCAuQm5+ZEHLYaNJcmlnnHl9Nani9ckRI7Db1qSr3I1vOsnU83wlHPfMtl3Gx1cUNw==}
+    peerDependencies:
+      webpack: ^5.37.0
+    dependencies:
+      '@vocab/core': 1.3.0
+      chalk: 4.1.2
+      debug: 4.3.4
+      es-module-lexer: 0.9.3
+      virtual-resource-loader: 1.0.1
+      webpack: 5.79.0(webpack-cli@5.0.1)
+    transitivePeerDependencies:
+      - supports-color
+
+  /@webassemblyjs/ast@1.11.1:
+    resolution: {integrity: sha512-ukBh14qFLjxTQNTXocdyksN5QdM28S1CxHt2rdskFyL+xFV7VremuBLVbmCePj+URalXBENx/9Lm7lnhihtCSw==}
+    dependencies:
+      '@webassemblyjs/helper-numbers': 1.11.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
+
+  /@webassemblyjs/floating-point-hex-parser@1.11.1:
+    resolution: {integrity: sha512-iGRfyc5Bq+NnNuX8b5hwBrRjzf0ocrJPI6GWFodBFzmFnyvrQ83SHKhmilCU/8Jv67i4GJZBMhEzltxzcNagtQ==}
+
+  /@webassemblyjs/helper-api-error@1.11.1:
+    resolution: {integrity: sha512-RlhS8CBCXfRUR/cwo2ho9bkheSXG0+NwooXcc3PAILALf2QLdFyj7KGsKRbVc95hZnhnERon4kW/D3SZpp6Tcg==}
+
+  /@webassemblyjs/helper-buffer@1.11.1:
+    resolution: {integrity: sha512-gwikF65aDNeeXa8JxXa2BAk+REjSyhrNC9ZwdT0f8jc4dQQeDQ7G4m0f2QCLPJiMTTO6wfDmRmj/pW0PsUvIcA==}
+
+  /@webassemblyjs/helper-numbers@1.11.1:
+    resolution: {integrity: sha512-vDkbxiB8zfnPdNK9Rajcey5C0w+QJugEglN0of+kmO8l7lDb77AnlKYQF7aarZuCrv+l0UvqL+68gSDr3k9LPQ==}
+    dependencies:
+      '@webassemblyjs/floating-point-hex-parser': 1.11.1
+      '@webassemblyjs/helper-api-error': 1.11.1
+      '@xtuc/long': 4.2.2
+
+  /@webassemblyjs/helper-wasm-bytecode@1.11.1:
+    resolution: {integrity: sha512-PvpoOGiJwXeTrSf/qfudJhwlvDQxFgelbMqtq52WWiXC6Xgg1IREdngmPN3bs4RoO83PnL/nFrxucXj1+BX62Q==}
+
+  /@webassemblyjs/helper-wasm-section@1.11.1:
+    resolution: {integrity: sha512-10P9No29rYX1j7F3EVPX3JvGPQPae+AomuSTPiF9eBQeChHI6iqjMIwR9JmOJXwpnn/oVGDk7I5IlskuMwU/pg==}
+    dependencies:
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/helper-buffer': 1.11.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
+      '@webassemblyjs/wasm-gen': 1.11.1
+
+  /@webassemblyjs/ieee754@1.11.1:
+    resolution: {integrity: sha512-hJ87QIPtAMKbFq6CGTkZYJivEwZDbQUgYd3qKSadTNOhVY7p+gfP6Sr0lLRVTaG1JjFj+r3YchoqRYxNH3M0GQ==}
+    dependencies:
+      '@xtuc/ieee754': 1.2.0
+
+  /@webassemblyjs/leb128@1.11.1:
+    resolution: {integrity: sha512-BJ2P0hNZ0u+Th1YZXJpzW6miwqQUGcIHT1G/sf72gLVD9DZ5AdYTqPNbHZh6K1M5VmKvFXwGSWZADz+qBWxeRw==}
+    dependencies:
+      '@xtuc/long': 4.2.2
+
+  /@webassemblyjs/utf8@1.11.1:
+    resolution: {integrity: sha512-9kqcxAEdMhiwQkHpkNiorZzqpGrodQQ2IGrHHxCy+Ozng0ofyMA0lTqiLkVs1uzTRejX+/O0EOT7KxqVPuXosQ==}
+
+  /@webassemblyjs/wasm-edit@1.11.1:
+    resolution: {integrity: sha512-g+RsupUC1aTHfR8CDgnsVRVZFJqdkFHpsHMfJuWQzWU3tvnLC07UqHICfP+4XyL2tnr1amvl1Sdp06TnYCmVkA==}
+    dependencies:
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/helper-buffer': 1.11.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
+      '@webassemblyjs/helper-wasm-section': 1.11.1
+      '@webassemblyjs/wasm-gen': 1.11.1
+      '@webassemblyjs/wasm-opt': 1.11.1
+      '@webassemblyjs/wasm-parser': 1.11.1
+      '@webassemblyjs/wast-printer': 1.11.1
+
+  /@webassemblyjs/wasm-gen@1.11.1:
+    resolution: {integrity: sha512-F7QqKXwwNlMmsulj6+O7r4mmtAlCWfO/0HdgOxSklZfQcDu0TpLiD1mRt/zF25Bk59FIjEuGAIyn5ei4yMfLhA==}
+    dependencies:
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
+      '@webassemblyjs/ieee754': 1.11.1
+      '@webassemblyjs/leb128': 1.11.1
+      '@webassemblyjs/utf8': 1.11.1
+
+  /@webassemblyjs/wasm-opt@1.11.1:
+    resolution: {integrity: sha512-VqnkNqnZlU5EB64pp1l7hdm3hmQw7Vgqa0KF/KCNO9sIpI6Fk6brDEiX+iCOYrvMuBWDws0NkTOxYEb85XQHHw==}
+    dependencies:
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/helper-buffer': 1.11.1
+      '@webassemblyjs/wasm-gen': 1.11.1
+      '@webassemblyjs/wasm-parser': 1.11.1
+
+  /@webassemblyjs/wasm-parser@1.11.1:
+    resolution: {integrity: sha512-rrBujw+dJu32gYB7/Lup6UhdkPx9S9SnobZzRVL7VcBH9Bt9bCBLEuX/YXOOtBsOZ4NQrRykKhffRWHvigQvOA==}
+    dependencies:
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/helper-api-error': 1.11.1
+      '@webassemblyjs/helper-wasm-bytecode': 1.11.1
+      '@webassemblyjs/ieee754': 1.11.1
+      '@webassemblyjs/leb128': 1.11.1
+      '@webassemblyjs/utf8': 1.11.1
+
+  /@webassemblyjs/wast-printer@1.11.1:
+    resolution: {integrity: sha512-IQboUWM4eKzWW+N/jij2sRatKMh99QEelo3Eb2q0qXkvPRISAj8Qxtmw5itwqK+TTkBuUIE45AxYPToqPtL5gg==}
+    dependencies:
+      '@webassemblyjs/ast': 1.11.1
+      '@xtuc/long': 4.2.2
+
+  /@webpack-cli/configtest@2.0.1(webpack-cli@5.0.1)(webpack@5.79.0):
+    resolution: {integrity: sha512-njsdJXJSiS2iNbQVS0eT8A/KPnmyH4pv1APj2K0d1wrZcBLw+yppxOy4CGqa0OxDJkzfL/XELDhD8rocnIwB5A==}
+    engines: {node: '>=14.15.0'}
+    peerDependencies:
+      webpack: 5.x.x
+      webpack-cli: 5.x.x
+    dependencies:
+      webpack: 5.79.0(webpack-cli@5.0.1)
+      webpack-cli: 5.0.1(webpack@5.79.0)
+
+  /@webpack-cli/info@2.0.1(webpack-cli@5.0.1)(webpack@5.79.0):
+    resolution: {integrity: sha512-fE1UEWTwsAxRhrJNikE7v4EotYflkEhBL7EbajfkPlf6E37/2QshOy/D48Mw8G5XMFlQtS6YV42vtbG9zBpIQA==}
+    engines: {node: '>=14.15.0'}
+    peerDependencies:
+      webpack: 5.x.x
+      webpack-cli: 5.x.x
+    dependencies:
+      webpack: 5.79.0(webpack-cli@5.0.1)
+      webpack-cli: 5.0.1(webpack@5.79.0)
+
+  /@webpack-cli/serve@2.0.1(webpack-cli@5.0.1)(webpack@5.79.0):
+    resolution: {integrity: sha512-0G7tNyS+yW8TdgHwZKlDWYXFA6OJQnoLCQvYKkQP0Q2X205PSQ6RNUj0M+1OB/9gRQaUZ/ccYfaxd0nhaWKfjw==}
+    engines: {node: '>=14.15.0'}
+    peerDependencies:
+      webpack: 5.x.x
+      webpack-cli: 5.x.x
+      webpack-dev-server: '*'
+    peerDependenciesMeta:
+      webpack-dev-server:
+        optional: true
+    dependencies:
+      webpack: 5.79.0(webpack-cli@5.0.1)
+      webpack-cli: 5.0.1(webpack@5.79.0)
+
+  /@xtuc/ieee754@1.2.0:
+    resolution: {integrity: sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==}
+
+  /@xtuc/long@4.2.2:
+    resolution: {integrity: sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==}
+
   /accepts@1.3.8:
     resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
     engines: {node: '>= 0.6'}
@@ -2828,6 +3116,13 @@ packages:
       mime-types: 2.1.35
       negotiator: 0.6.3
     dev: false
+
+  /acorn-import-assertions@1.8.0(acorn@8.8.2):
+    resolution: {integrity: sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==}
+    peerDependencies:
+      acorn: ^8
+    dependencies:
+      acorn: 8.8.2
 
   /acorn-jsx@5.3.2(acorn@8.8.2):
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2850,6 +3145,13 @@ packages:
   /ahocorasick@1.0.2:
     resolution: {integrity: sha512-hCOfMzbFx5IDutmWLAt6MZwOUjIfSM9G9FyVxytmE4Rs/5YDPWQrD/+IR1w+FweD9H2oOZEnv36TmkjhNURBVA==}
     dev: false
+
+  /ajv-keywords@3.5.2(ajv@6.12.6):
+    resolution: {integrity: sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==}
+    peerDependencies:
+      ajv: ^6.9.1
+    dependencies:
+      ajv: 6.12.6
 
   /ajv@6.12.6:
     resolution: {integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==}
@@ -2882,7 +3184,6 @@ packages:
   /ansi-regex@5.0.1:
     resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
     engines: {node: '>=8'}
-    dev: false
 
   /ansi-regex@6.0.1:
     resolution: {integrity: sha512-n5M855fKb2SsfMIiFFoVrABHJC8QtHwVx+mHWP3QcEqBHYienj5dHSgjbxtC0WEZXYt4wcD6zrQElDPhFuZgfA==}
@@ -2899,7 +3200,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       color-convert: 2.0.1
-    dev: false
 
   /ansi-styles@5.2.0:
     resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
@@ -2912,7 +3212,6 @@ packages:
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.3.1
-    dev: false
 
   /argparse@1.0.10:
     resolution: {integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==}
@@ -3114,10 +3413,12 @@ packages:
       is-windows: 1.0.2
     dev: false
 
+  /big.js@5.2.2:
+    resolution: {integrity: sha512-vyL2OymJxmarO8gxMr0mhChsO9QGwhynfuu4+MHTAW6czfq9humCB7rKpUjDd9YUiDPU4mzpyupFSvOClAwbmQ==}
+
   /binary-extensions@2.2.0:
     resolution: {integrity: sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==}
     engines: {node: '>=8'}
-    dev: false
 
   /blueimp-md5@2.19.0:
     resolution: {integrity: sha512-DRQrD6gJyy8FbiE4s+bDoXS9hiW3Vbx5uCdwvcCf3zLHL+Iv7LtGHLpr+GZV8rHG8tK766FGYBwRbu8pELTt+w==}
@@ -3227,7 +3528,6 @@ packages:
 
   /buffer-from@1.1.2:
     resolution: {integrity: sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==}
-    dev: false
 
   /builtin-modules@3.3.0:
     resolution: {integrity: sha512-zhaCDicdLuWN5UbN5IMnFqNMhNfo919sH85y2/ea+5Yg9TsTkeZxpL+JLbp6cgYFS4sRLp3YV4S6yDuqVWHYOw==}
@@ -3314,7 +3614,6 @@ packages:
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
-    dev: false
 
   /chalk@5.2.0:
     resolution: {integrity: sha512-ree3Gqw/nazQAPuJJEy+avdl7QfZMcUvmHIKgEZkGL+xOBzRvup5Hxo6LHuMceSxOabuJLJm5Yp/92R9eMmMvA==}
@@ -3342,7 +3641,10 @@ packages:
       readdirp: 3.6.0
     optionalDependencies:
       fsevents: 2.3.2
-    dev: false
+
+  /chrome-trace-event@1.0.3:
+    resolution: {integrity: sha512-p3KULyQg4S7NIHixdwbGX+nFHkoBiA4YQmyWtjb8XngSKV124nJmRysgAeujbUVb15vh+RvFUfCPqU7rXk+hZg==}
+    engines: {node: '>=6.0'}
 
   /ci-info@2.0.0:
     resolution: {integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==}
@@ -3387,6 +3689,14 @@ packages:
       wrap-ansi: 6.2.0
     dev: false
 
+  /cliui@7.0.4:
+    resolution: {integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==}
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 7.0.0
+    dev: true
+
   /cliui@8.0.1:
     resolution: {integrity: sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==}
     engines: {node: '>=12'}
@@ -3395,6 +3705,14 @@ packages:
       strip-ansi: 6.0.1
       wrap-ansi: 7.0.0
     dev: false
+
+  /clone-deep@4.0.1:
+    resolution: {integrity: sha512-neHB9xuzh/wk0dIHweyAXv2aPGZIVk3pLMe+/RNzINf17fe0OG96QroktYAUm7SM1PBnzTabaLboqqxDyMU+SQ==}
+    engines: {node: '>=6'}
+    dependencies:
+      is-plain-object: 2.0.4
+      kind-of: 6.0.3
+      shallow-clone: 3.0.1
 
   /clone@1.0.4:
     resolution: {integrity: sha512-JQHZ2QMW6l3aH/j6xCqQThY/9OH4D/9ls34cgkUBiEeocRTU04tHfKPBsUK1PqZCUQM7GiA0IIXJSuXHI64Kbg==}
@@ -3427,20 +3745,28 @@ packages:
     engines: {node: '>=7.0.0'}
     dependencies:
       color-name: 1.1.4
-    dev: false
 
   /color-name@1.1.3:
     resolution: {integrity: sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==}
 
   /color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
-    dev: false
+
+  /colorette@2.0.19:
+    resolution: {integrity: sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==}
 
   /combined-stream@1.0.8:
     resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
     engines: {node: '>= 0.8'}
     dependencies:
       delayed-stream: 1.0.0
+
+  /commander@2.20.3:
+    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
+
+  /commander@9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
 
   /commondir@1.0.1:
     resolution: {integrity: sha512-W9pAhw0ja1Edb5GVdIF1mjZw/ASI0AlShXM83UUGe2DVr5TdAPEA1OA8m/g8zWp9x6On7gqufY+FatDbC3MDQg==}
@@ -3536,7 +3862,6 @@ packages:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
-    dev: false
 
   /crypto-random-string@1.0.0:
     resolution: {integrity: sha512-GsVpkFPlycH7/fRR7Dhcmnoii54gV1nz7y4CWyeFS14N+JVBBhY+r8amRHE4BwSYal7BPTDp8isvAlCxyFt3Hg==}
@@ -3568,6 +3893,10 @@ packages:
   /csv-stringify@5.6.5:
     resolution: {integrity: sha512-PjiQ659aQ+fUTQqSrd1XEDnOr52jh30RBurfzkscaE2tPaFsDH5wOAHJiw8XAHphRknCwMUE9KRayc4K/NbO8A==}
     dev: false
+
+  /csv-stringify@6.3.0:
+    resolution: {integrity: sha512-kTnnBkkLmAR1G409aUdShppWUClNbBQZXhrKrXzKYBGw4yfROspiFvVmjbKonCrdGfwnqwMXKLQG7ej7K/jwjg==}
+    dev: true
 
   /csv@5.5.3:
     resolution: {integrity: sha512-QTaY0XjjhTQOdguARF0lGKm5/mEq9PD9/VhZZegHDIBq2tQwgNpHc3dneD4mGo2iJs+fTKv5Bp0fZ+BRuY3Z0g==}
@@ -3767,7 +4096,10 @@ packages:
 
   /emoji-regex@8.0.0:
     resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
-    dev: false
+
+  /emojis-list@3.0.0:
+    resolution: {integrity: sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==}
+    engines: {node: '>= 4'}
 
   /encodeurl@1.0.2:
     resolution: {integrity: sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==}
@@ -3785,7 +4117,6 @@ packages:
     dependencies:
       graceful-fs: 4.2.10
       tapable: 2.2.1
-    dev: false
 
   /enquirer@2.3.6:
     resolution: {integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==}
@@ -3797,6 +4128,20 @@ packages:
   /ensure-gitignore@1.2.0:
     resolution: {integrity: sha512-CfkUKQsT1/2BdpF1XXGs8/8CZQK2JMAIsl3bHUwFS/fsBU58Mn+iZ6qd2vFxupWJTZA0Din0USWdu6UbojV3sQ==}
     dev: false
+
+  /env-ci@5.5.0:
+    resolution: {integrity: sha512-o0JdWIbOLP+WJKIUt36hz1ImQQFuN92nhsfTkHHap+J8CiI8WgGpH/a9jEGHh4/TU5BUUGjlnKXNoDb57+ne+A==}
+    engines: {node: '>=10.17'}
+    dependencies:
+      execa: 5.1.1
+      fromentries: 1.3.2
+      java-properties: 1.0.2
+    dev: true
+
+  /envinfo@7.8.1:
+    resolution: {integrity: sha512-/o+BXHmB7ocbHEAs6F2EnG0ogybVVUdkRunTT2glZU9XAaGmhqskrvKwqXuDfNjEO0LZKWdejEEpnq8aM0tOaw==}
+    engines: {node: '>=4'}
+    hasBin: true
 
   /error-ex@1.3.2:
     resolution: {integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==}
@@ -3842,9 +4187,11 @@ packages:
       which-typed-array: 1.1.9
     dev: false
 
+  /es-module-lexer@0.9.3:
+    resolution: {integrity: sha512-1HQ2M2sPtxwnvOvT1ZClHyQDiggdNjURWpY2we6aMKCQiUVxTmVs2UYPLIrD84sS+kMdUwfBSylbJPwNnBrnHQ==}
+
   /es-module-lexer@1.2.1:
     resolution: {integrity: sha512-9978wrXM50Y4rTMmW5kXIC09ZdXQZqkE4mxhwkd8VbzsGkXGPgV4zWuqQJgCEzYngdo2dYDa0l8xhX4fkSwJSg==}
-    dev: false
 
   /es-set-tostringtag@2.0.0:
     resolution: {integrity: sha512-vZVAIWss0FcR/+a08s6e2/GjGjjYBCZJXDrOnj6l5kJCKhQvJs4cnVqUxkVepIhqHbKHm3uwOvPb8lRcqA3DSg==}
@@ -4398,7 +4745,6 @@ packages:
     dependencies:
       esrecurse: 4.3.0
       estraverse: 4.3.0
-    dev: false
 
   /eslint-scope@7.1.1:
     resolution: {integrity: sha512-QKQM/UXpIiHcLqJ5AOyIW7XZmzjkzQXYE54n1++wb0u9V/abW3l9uQnxX8Z5Xd18xyKIMTUAyQ0k1e8pz6LUrw==}
@@ -4502,17 +4848,14 @@ packages:
     engines: {node: '>=4.0'}
     dependencies:
       estraverse: 5.3.0
-    dev: false
 
   /estraverse@4.3.0:
     resolution: {integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==}
     engines: {node: '>=4.0'}
-    dev: false
 
   /estraverse@5.3.0:
     resolution: {integrity: sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==}
     engines: {node: '>=4.0'}
-    dev: false
 
   /estree-walker@2.0.2:
     resolution: {integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==}
@@ -4543,6 +4886,10 @@ packages:
       require-like: 0.1.2
     dev: false
 
+  /events@3.3.0:
+    resolution: {integrity: sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==}
+    engines: {node: '>=0.8.x'}
+
   /execa@1.0.0:
     resolution: {integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==}
     engines: {node: '>=6'}
@@ -4554,6 +4901,21 @@ packages:
       p-finally: 1.0.0
       signal-exit: 3.0.7
       strip-eof: 1.0.0
+
+  /execa@5.1.1:
+    resolution: {integrity: sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==}
+    engines: {node: '>=10'}
+    dependencies:
+      cross-spawn: 7.0.3
+      get-stream: 6.0.1
+      human-signals: 2.1.0
+      is-stream: 2.0.1
+      merge-stream: 2.0.0
+      npm-run-path: 4.0.1
+      onetime: 5.1.2
+      signal-exit: 3.0.7
+      strip-final-newline: 2.0.0
+    dev: true
 
   /expect@29.0.2:
     resolution: {integrity: sha512-JeJlAiLKn4aApT4pzUXBVxl3NaZidWIOdg//smaIlP9ZMBDkHZGFd9ubphUZP9pUyDEo7bC6M0IIZR51o75qQw==}
@@ -4659,6 +5021,13 @@ packages:
       punycode: 1.4.1
     dev: false
 
+  /fastest-levenshtein@1.0.16:
+    resolution: {integrity: sha512-eRnCtTTtGZFpQCwhJiUOuxPQWRXVKYDn0b2PeHfXL6/Zi53SLAzAHfVhVWK2AryC/WH05kGfxhFIPvTF0SXQzg==}
+    engines: {node: '>= 4.9.1'}
+
+  /fastest-validator@1.16.0:
+    resolution: {integrity: sha512-+C1cFoLboOZIZs2PWhceNtJ15zCoiRalu1LnJB4hy63Y8Tto9bkqGcTGkzegt+Xu4qy3LE9GL6CLzEdpZ5xJBQ==}
+
   /fastq@1.13.0:
     resolution: {integrity: sha512-YpkpUnK8od0o1hmeSc7UUs/eB/vIPWJYjKck2QKIzAf71Vm1AAQ3EbuZB3g2JIy+pg+ERD0vqI79KyZiB2e2Nw==}
     dependencies:
@@ -4714,7 +5083,6 @@ packages:
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
-    dev: false
 
   /find-up@5.0.0:
     resolution: {integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==}
@@ -4722,7 +5090,6 @@ packages:
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
-    dev: false
 
   /find-yarn-workspace-root2@1.2.16:
     resolution: {integrity: sha512-hr6hb1w8ePMpPVUK39S4RlwJzi+xPLuVuG8XlwXU3KD5Yn3qgBWVfy3AzNlDhWvE1EORCE65/Qm26rFQt3VLVA==}
@@ -4786,6 +5153,15 @@ packages:
       combined-stream: 1.0.8
       mime-types: 2.1.35
 
+  /form-data@3.0.1:
+    resolution: {integrity: sha512-RHkBKtLWUVwd7SqRIvCZMEvAMoGUp0XU+seQiZejj0COz3RI3hWP4sCv3gZWWLjJTd7rGwcsF5eKZGii0r/hbg==}
+    engines: {node: '>= 6'}
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      mime-types: 2.1.35
+    dev: true
+
   /form-data@4.0.0:
     resolution: {integrity: sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==}
     engines: {node: '>= 6'}
@@ -4804,6 +5180,10 @@ packages:
     resolution: {integrity: sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==}
     engines: {node: '>= 0.6'}
     dev: false
+
+  /fromentries@1.3.2:
+    resolution: {integrity: sha512-cHEpEQHUg0f8XdtZCc2ZAhrHzKzT0MrFUTcvx+hfxYu7rGMDc5SKoXFh+n4YigxsHXRzc6OrCshdR1bWH6HHyg==}
+    dev: true
 
   /fs-extra@10.1.0:
     resolution: {integrity: sha512-oRXApq54ETRj4eMiFzGnHWGy+zo5raudjuxN0b8H7s/RU2oW0Wvsx9O0ACRN/kRq9E8Vu/ReskGB5o3ji+FzHQ==}
@@ -4895,7 +5275,6 @@ packages:
   /get-caller-file@2.0.5:
     resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
     engines: {node: 6.* || 8.* || >= 10.*}
-    dev: false
 
   /get-func-name@2.0.0:
     resolution: {integrity: sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==}
@@ -4924,6 +5303,11 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       pump: 3.0.0
+
+  /get-stream@6.0.1:
+    resolution: {integrity: sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==}
+    engines: {node: '>=10'}
+    dev: true
 
   /get-symbol-description@1.0.0:
     resolution: {integrity: sha512-2EmdH1YvIQiZpltCNgkuiUnyukzxM/R6NDJX31Ke3BG1Nq5b0S2PhX59UKi9vZpPDQVdqn+1IcaAwnzTT5vCjw==}
@@ -4961,7 +5345,6 @@ packages:
 
   /glob-to-regexp@0.4.1:
     resolution: {integrity: sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==}
-    dev: false
 
   /glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
@@ -5105,7 +5488,6 @@ packages:
   /has-flag@4.0.0:
     resolution: {integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==}
     engines: {node: '>=8'}
-    dev: false
 
   /has-property-descriptors@1.0.0:
     resolution: {integrity: sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==}
@@ -5166,6 +5548,11 @@ packages:
     resolution: {integrity: sha512-UNopramDEhHJD+VR+ehk8rOslwSfByxPIZyJRfV739NDhN5LF1fa1MqnzKm2lGTQRjNrjK19Q5fhkgIfjlVUKw==}
     dev: false
 
+  /human-signals@2.1.0:
+    resolution: {integrity: sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==}
+    engines: {node: '>=10.17.0'}
+    dev: true
+
   /iconv-lite@0.4.24:
     resolution: {integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==}
     engines: {node: '>=0.10.0'}
@@ -5201,6 +5588,14 @@ packages:
       parent-module: 1.0.1
       resolve-from: 4.0.0
     dev: false
+
+  /import-local@3.1.0:
+    resolution: {integrity: sha512-ASB07uLtnDs1o6EHjKpX34BKYDSqnFerfTOJL2HvMqF70LnxpjkzDB8J44oT9pu4AMPkQwf8jl6szgvNd2tRIg==}
+    engines: {node: '>=8'}
+    hasBin: true
+    dependencies:
+      pkg-dir: 4.2.0
+      resolve-cwd: 3.0.0
 
   /imurmurhash@0.1.4:
     resolution: {integrity: sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA==}
@@ -5261,7 +5656,7 @@ packages:
       scheduler: 0.20.2
       signal-exit: 3.0.7
       slice-ansi: 3.0.0
-      stack-utils: 2.0.5
+      stack-utils: 2.0.6
       string-width: 4.2.3
       type-fest: 0.12.0
       widest-line: 3.1.0
@@ -5281,6 +5676,18 @@ packages:
       has: 1.0.3
       side-channel: 1.0.4
     dev: false
+
+  /interpret@3.1.1:
+    resolution: {integrity: sha512-6xwYfHbajpoF0xLW+iwLkhwgvLoZDfjYfoFNu8ftMoXINzwuymNLd9u/KmwtdT2GbR+/Cz66otEGEVVUHX9QLQ==}
+    engines: {node: '>=10.13.0'}
+
+  /intl-messageformat@10.3.3:
+    resolution: {integrity: sha512-un/f07/g2e/3Q8e1ghDKET+el22Bi49M7O/rHxd597R+oLpPOMykSv5s51cABVfu3FZW+fea4hrzf2MHu1W4hw==}
+    dependencies:
+      '@formatjs/ecma402-abstract': 1.14.3
+      '@formatjs/fast-memoize': 2.0.1
+      '@formatjs/icu-messageformat-parser': 2.3.0
+      tslib: 2.4.0
 
   /invariant@2.2.4:
     resolution: {integrity: sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==}
@@ -5327,7 +5734,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       binary-extensions: 2.2.0
-    dev: false
 
   /is-boolean-object@1.1.2:
     resolution: {integrity: sha512-gDYaKHJmnj4aWxyj6YHyXVpdQawtVLHU5cb+eztPGczf6cjuTdwve5ZIEfgXqH4e57An1D1AKf8CZ3kYrQRqYA==}
@@ -5398,7 +5804,6 @@ packages:
   /is-fullwidth-code-point@3.0.0:
     resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
     engines: {node: '>=8'}
-    dev: false
 
   /is-generator-function@1.0.10:
     resolution: {integrity: sha512-jsEjy9l3yiXEQ+PsXdmBwEPcOxaXWLspKdplFUVI9vq1iZgIekeC0L167qeu86czQaxed3q/Uzuw0swL0irL8A==}
@@ -5455,6 +5860,12 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
+  /is-plain-object@2.0.4:
+    resolution: {integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==}
+    engines: {node: '>=0.10.0'}
+    dependencies:
+      isobject: 3.0.1
+
   /is-reference@1.2.1:
     resolution: {integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==}
     dependencies:
@@ -5478,6 +5889,11 @@ packages:
   /is-stream@1.1.0:
     resolution: {integrity: sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==}
     engines: {node: '>=0.10.0'}
+
+  /is-stream@2.0.1:
+    resolution: {integrity: sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==}
+    engines: {node: '>=8'}
+    dev: true
 
   /is-string@1.0.7:
     resolution: {integrity: sha512-tE2UXzivje6ofPW7l23cjDOMa09gb7xlAqG6jG5ej6uPV32TlWP3NKPigtaGeHNu9fohccRYvIiZMfOOnOYUtg==}
@@ -5535,6 +5951,10 @@ packages:
   /isexe@2.0.0:
     resolution: {integrity: sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==}
 
+  /isobject@3.0.1:
+    resolution: {integrity: sha512-WhB9zCku7EGTj/HQQRz5aUQEUeoQZH2bWcltRErOpymJ4boYE6wL9Tbr23krRPSZ+C5zqNSrSw+Cc7sZZ4b7vg==}
+    engines: {node: '>=0.10.0'}
+
   /isstream@0.1.2:
     resolution: {integrity: sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==}
 
@@ -5555,6 +5975,11 @@ packages:
     transitivePeerDependencies:
       - supports-color
     dev: false
+
+  /java-properties@1.0.2:
+    resolution: {integrity: sha512-qjdpeo2yKlYTH7nFdK0vbZWuTCesk4o63v5iVOlhMQPfuIZQfW/HI35SjfhA+4qpg36rnFSvUK5b1m+ckIblQQ==}
+    engines: {node: '>= 0.6.0'}
+    dev: true
 
   /javascript-stringify@2.1.0:
     resolution: {integrity: sha512-JVAfqNPTvNq3sB/VHQJAFxN/sPgKnsKrCwyRt15zwNCdrMMJDdcEOdubuy+DuJYYdm0ox1J4uzEuYKkN+9yhVg==}
@@ -5668,6 +6093,14 @@ packages:
       picomatch: 2.3.1
     dev: false
 
+  /jest-worker@27.5.1:
+    resolution: {integrity: sha512-7vuh85V5cdDofPyxn58nrPjBktZo0u9x1g8WtjQol+jZDaE+fhN+cIvTj11GndBnMnyfrUOG1sZQxCdjKh+DKg==}
+    engines: {node: '>= 10.13.0'}
+    dependencies:
+      '@types/node': 18.11.17
+      merge-stream: 2.0.0
+      supports-color: 8.1.1
+
   /jest-worker@29.0.2:
     resolution: {integrity: sha512-EyvBlYcvd2pg28yg5A3OODQnqK9LI1kitnGUZUG5/NYIeaRgewtYBKB5wlr7oXj8zPCkzev7EmnTCsrXK7V+Xw==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -5719,7 +6152,6 @@ packages:
 
   /json-parse-even-better-errors@2.3.1:
     resolution: {integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==}
-    dev: false
 
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
@@ -5790,7 +6222,6 @@ packages:
   /kind-of@6.0.3:
     resolution: {integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
@@ -5830,6 +6261,18 @@ packages:
       strip-bom: 3.0.0
     dev: false
 
+  /loader-runner@4.3.0:
+    resolution: {integrity: sha512-3R/1M+yS3j5ou80Me59j7F9IMs4PXs3VqRrm0TU3AbKPxlmpoY1TNscJV/oGJXo8qCatFGTfDbY6W6ipGOYXfg==}
+    engines: {node: '>=6.11.5'}
+
+  /loader-utils@2.0.4:
+    resolution: {integrity: sha512-xXqpXoINfFhgua9xiqD8fPFHgkoq1mmmpE92WlDbm9rNRd/EbRb+Gqf908T2DMfuHjjJlksiK2RbHVOdD/MqSw==}
+    engines: {node: '>=8.9.0'}
+    dependencies:
+      big.js: 5.2.2
+      emojis-list: 3.0.0
+      json5: 2.2.3
+
   /local-pkg@0.4.3:
     resolution: {integrity: sha512-SFppqq5p42fe2qcZQqqEOiVRXl+WCP1MdT6k7BDEW1j++sp5fIY+/fdRQitvKgB5BrBcmrs5m/L0v2FrU5MY1g==}
     engines: {node: '>=14'}
@@ -5847,14 +6290,12 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-locate: 4.1.0
-    dev: false
 
   /locate-path@6.0.0:
     resolution: {integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==}
     engines: {node: '>=10'}
     dependencies:
       p-locate: 5.0.0
-    dev: false
 
   /lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
@@ -6012,7 +6453,6 @@ packages:
 
   /merge-stream@2.0.0:
     resolution: {integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==}
-    dev: false
 
   /merge2@1.4.1:
     resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
@@ -6168,6 +6608,9 @@ packages:
     engines: {node: '>= 0.6'}
     dev: false
 
+  /neo-async@2.6.2:
+    resolution: {integrity: sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==}
+
   /nice-try@1.0.5:
     resolution: {integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==}
 
@@ -6181,7 +6624,6 @@ packages:
         optional: true
     dependencies:
       whatwg-url: 5.0.0
-    dev: false
 
   /node-int64@0.4.0:
     resolution: {integrity: sha512-O5lz91xSOeoXP6DulyHfllpq+Eg00MWitZIbtPfoSEvqIHdl5gfcY6hYzDWnj0qD5tz52PI08u9qUvSVeUBeHw==}
@@ -6202,7 +6644,6 @@ packages:
   /normalize-path@3.0.0:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /npm-package-arg@6.1.1:
     resolution: {integrity: sha512-qBpssaL3IOZWi5vEKUKW0cO7kzLeT+EQO9W8RsLOZf76KF9E/K9+wH0C7t06HXPpaH8WH5xF1MExLuCwbTqRUg==}
@@ -6217,6 +6658,13 @@ packages:
     engines: {node: '>=4'}
     dependencies:
       path-key: 2.0.1
+
+  /npm-run-path@4.0.1:
+    resolution: {integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==}
+    engines: {node: '>=8'}
+    dependencies:
+      path-key: 3.1.1
+    dev: true
 
   /number-is-nan@1.0.1:
     resolution: {integrity: sha512-4jbtZXNAsfZbAHiiqjLPBiCl16dES1zI4Hpzzxw61Tk+loF+sBDBKx1ICKKKwIqQ7M0mFn1TmkN7euSncWgHiQ==}
@@ -6308,7 +6756,6 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       mimic-fn: 2.1.0
-    dev: false
 
   /open@8.4.0:
     resolution: {integrity: sha512-XgFPPM+B28FtCCgSb9I+s9szOC1vZRSwgWsRUA5ylIxRTgKozqjOCrVOqGsYABPYK5qnfqClxZTFBa8PKt2v6Q==}
@@ -6391,14 +6838,12 @@ packages:
     engines: {node: '>=6'}
     dependencies:
       p-try: 2.2.0
-    dev: false
 
   /p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
     dependencies:
       yocto-queue: 0.1.0
-    dev: false
 
   /p-limit@4.0.0:
     resolution: {integrity: sha512-5b0R4txpzjPWVw/cXXUResoD4hb6U/x9BH08L7nw+GN1sezDzPdxeRvpc9c433fZhBan/wusjbCsqwqm4EIBIQ==}
@@ -6418,14 +6863,12 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       p-limit: 2.3.0
-    dev: false
 
   /p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
     dependencies:
       p-limit: 3.1.0
-    dev: false
 
   /p-map@2.1.0:
     resolution: {integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==}
@@ -6439,7 +6882,6 @@ packages:
   /p-try@2.2.0:
     resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
     engines: {node: '>=6'}
-    dev: false
 
   /parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
@@ -6480,7 +6922,6 @@ packages:
   /path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
-    dev: false
 
   /path-is-absolute@1.0.1:
     resolution: {integrity: sha512-AVbw3UJ2e9bq64vSaS9Am0fje1Pa8pbGqTTsmXfaIiMpnr5DlDhfJOuLj9Sf95ZPVDAUerDfEk88MPmPe7UCQg==}
@@ -6498,7 +6939,6 @@ packages:
   /path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
     engines: {node: '>=8'}
-    dev: false
 
   /path-parse@1.0.7:
     resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
@@ -6563,7 +7003,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       find-up: 4.1.0
-    dev: false
 
   /pkg-types@1.0.2:
     resolution: {integrity: sha512-hM58GKXOcj8WTqUXnsQyJYXdeAPbythQgEF3nTcEo+nkD49chjQ9IKm/QJy9xf6JakXptz86h7ecP2024rrLaQ==}
@@ -6745,7 +7184,6 @@ packages:
     resolution: {integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==}
     dependencies:
       safe-buffer: 5.2.1
-    dev: false
 
   /range-parser@1.2.0:
     resolution: {integrity: sha512-kA5WQoNVo4t9lNx2kQNFCxKeBl5IbbSNBl1M/tLkw9WCn+hxNBAW5Qh8gdhs63CJnhjJ2zQWFoqPJP2sK1AV5A==}
@@ -6998,7 +7436,12 @@ packages:
     engines: {node: '>=8.10.0'}
     dependencies:
       picomatch: 2.3.1
-    dev: false
+
+  /rechoir@0.8.0:
+    resolution: {integrity: sha512-/vxpCXddiX8NGfGO/mTafwjq4aFa/71pvamip0++IQk3zG8cbCj0fifNPrjjF1XMXUne91jL9OoxmdykoEtifQ==}
+    engines: {node: '>= 10.13.0'}
+    dependencies:
+      resolve: 1.22.1
 
   /redent@3.0.0:
     resolution: {integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==}
@@ -7075,6 +7518,12 @@ packages:
     resolution: {integrity: sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ==}
     dev: false
 
+  /resolve-cwd@3.0.0:
+    resolution: {integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==}
+    engines: {node: '>=8'}
+    dependencies:
+      resolve-from: 5.0.0
+
   /resolve-from@4.0.0:
     resolution: {integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==}
     engines: {node: '>=4'}
@@ -7083,7 +7532,6 @@ packages:
   /resolve-from@5.0.0:
     resolution: {integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==}
     engines: {node: '>=8'}
-    dev: false
 
   /resolve@1.22.1:
     resolution: {integrity: sha512-nBpuuYuY5jFsli/JIs1oldw6fOQCBioohqWZg/2hiaOybXOft4lonv85uDOKXdf8rhyK159cxU5cDcK/NKk8zw==}
@@ -7205,6 +7653,14 @@ packages:
     dependencies:
       loose-envify: 1.4.0
 
+  /schema-utils@3.1.1:
+    resolution: {integrity: sha512-Y5PQxS4ITlC+EahLuXaY86TXfR7Dc5lw294alXOq86JAHCihAIZfqv8nNCWvaEJvaC51uN9hbLGeV0cFBdH+Fw==}
+    engines: {node: '>= 10.13.0'}
+    dependencies:
+      '@types/json-schema': 7.0.11
+      ajv: 6.12.6
+      ajv-keywords: 3.5.2(ajv@6.12.6)
+
   /scule@1.0.0:
     resolution: {integrity: sha512-4AsO/FrViE/iDNEPaAQlb77tf0csuq27EsVpy6ett584EcRTp6pTDLoGWVxCD77y5iU5FauOvhsI4o1APwPoSQ==}
     dev: true
@@ -7252,6 +7708,11 @@ packages:
       randombytes: 2.1.0
     dev: false
 
+  /serialize-javascript@6.0.1:
+    resolution: {integrity: sha512-owoXEFjWRllis8/M1Q+Cw5k8ZH40e3zhp/ovX+Xr/vi1qj6QesbyXXViFbpNvWvPNAD62SutwEXavefrLJWj7w==}
+    dependencies:
+      randombytes: 2.1.0
+
   /serve-handler@6.1.5:
     resolution: {integrity: sha512-ijPFle6Hwe8zfmBxJdE+5fta53fdIY0lHISJvuikXB3VYFafRjMRpOffSPvCYsbKyBA7pvy9oYr/BT1O3EArlg==}
     dependencies:
@@ -7284,6 +7745,12 @@ packages:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
     dev: false
 
+  /shallow-clone@3.0.1:
+    resolution: {integrity: sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==}
+    engines: {node: '>=8'}
+    dependencies:
+      kind-of: 6.0.3
+
   /shebang-command@1.2.0:
     resolution: {integrity: sha512-EV3L1+UQWGor21OmnvojK36mhg+TyIKDh3iFBKBohr5xeXIhNBcx8oWdgkTEEQ+BEFFYdLRuqMfd5L84N1V5Vg==}
     engines: {node: '>=0.10.0'}
@@ -7295,7 +7762,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       shebang-regex: 3.0.0
-    dev: false
 
   /shebang-regex@1.0.0:
     resolution: {integrity: sha512-wpoSFAxys6b2a2wHZ1XpDSgD7N9iVjg29Ph9uV/uaP9Ex/KXlkTZTeddxDPSYQpgvzKLGJke2UU0AzoGCjNIvQ==}
@@ -7304,7 +7770,6 @@ packages:
   /shebang-regex@3.0.0:
     resolution: {integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==}
     engines: {node: '>=8'}
-    dev: false
 
   /shell-quote@1.7.3:
     resolution: {integrity: sha512-Vpfqwm4EnqGdlsBFNmHhxhElJYrdfcxPThu+ryKS5J8L/fhAwLazFZtq+S+TWZ9ANj2piSQLGj6NQg+lKPmxrw==}
@@ -7403,12 +7868,10 @@ packages:
     dependencies:
       buffer-from: 1.1.2
       source-map: 0.6.1
-    dev: false
 
   /source-map@0.6.1:
     resolution: {integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==}
     engines: {node: '>=0.10.0'}
-    dev: false
 
   /spawndamnit@2.0.0:
     resolution: {integrity: sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==}
@@ -7465,6 +7928,13 @@ packages:
       escape-string-regexp: 2.0.0
     dev: false
 
+  /stack-utils@2.0.6:
+    resolution: {integrity: sha512-XlkWvfIm6RmsWtNJx+uqtKLS8eqFbxUg0ZzLXqY0caEy9l7hruX8IpiDnjsLavoBgqCCR71TqWO8MaXYheJ3RQ==}
+    engines: {node: '>=10'}
+    dependencies:
+      escape-string-regexp: 2.0.0
+    dev: false
+
   /stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
     dev: false
@@ -7506,7 +7976,6 @@ packages:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.1
-    dev: false
 
   /string.prototype.matchall@4.0.8:
     resolution: {integrity: sha512-6zOCOcJ+RJAQshcTvXPHoxoQGONa3e/Lqx90wUA+wEzX78sg5Bo+1tQo4N0pohS0erG9qtCqJDjNCQBjeWVxyg==}
@@ -7554,7 +8023,6 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       ansi-regex: 5.0.1
-    dev: false
 
   /strip-ansi@7.0.1:
     resolution: {integrity: sha512-cXNxvT8dFNRVfhVME3JAe98mkXDYN2O1l7jmcwMnOslDeESg1rF/OZMtK0nRAhiari1unG5cD4jG3rapUAkLbw==}
@@ -7570,6 +8038,11 @@ packages:
   /strip-eof@1.0.0:
     resolution: {integrity: sha512-7FCwGGmx8mD5xQd3RPUvnSpUXHM3BWuzjtpD4TXsfcZ9EL4azvVVUscFYwD9nx8Kh+uCBC00XBtAykoMHwTh8Q==}
     engines: {node: '>=0.10.0'}
+
+  /strip-final-newline@2.0.0:
+    resolution: {integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==}
+    engines: {node: '>=6'}
+    dev: true
 
   /strip-indent@3.0.0:
     resolution: {integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==}
@@ -7599,14 +8072,12 @@ packages:
     engines: {node: '>=8'}
     dependencies:
       has-flag: 4.0.0
-    dev: false
 
   /supports-color@8.1.1:
     resolution: {integrity: sha512-MpUEN2OodtUzxvKQl72cUF7RQ5EiHsGvSsVG0ia9c5RbWGL2CI4C7EpPS8UTBIplnlzZiNuV56w+FuNxy3ty2Q==}
     engines: {node: '>=10'}
     dependencies:
       has-flag: 4.0.0
-    dev: false
 
   /supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
@@ -7632,7 +8103,6 @@ packages:
   /tapable@2.2.1:
     resolution: {integrity: sha512-GNzQvQTOIP6RyTfE2Qxb8ZVlNmw0n88vp1szwWRimP02mnTsx3Wtn5qRdqY9w2XduFNUgvOwhNnQsjwCp+kqaQ==}
     engines: {node: '>=6'}
-    dev: false
 
   /temp-dir@1.0.0:
     resolution: {integrity: sha512-xZFXEGbG7SNC3itwBzI3RYjq/cEhBkx2hJuKGIUOcEULmkQExXiHat2z/qkISYsuR+IKumhEfKKbV5qXmhICFQ==}
@@ -7651,6 +8121,39 @@ packages:
     resolution: {integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==}
     engines: {node: '>=8'}
     dev: false
+
+  /terser-webpack-plugin@5.3.7(webpack@5.79.0):
+    resolution: {integrity: sha512-AfKwIktyP7Cu50xNjXF/6Qb5lBNzYaWpU6YfoX3uZicTx0zTy0stDDCsvjDapKsSDvOeWo5MEq4TmdBy2cNoHw==}
+    engines: {node: '>= 10.13.0'}
+    peerDependencies:
+      '@swc/core': '*'
+      esbuild: '*'
+      uglify-js: '*'
+      webpack: ^5.1.0
+    peerDependenciesMeta:
+      '@swc/core':
+        optional: true
+      esbuild:
+        optional: true
+      uglify-js:
+        optional: true
+    dependencies:
+      '@jridgewell/trace-mapping': 0.3.17
+      jest-worker: 27.5.1
+      schema-utils: 3.1.1
+      serialize-javascript: 6.0.1
+      terser: 5.16.9
+      webpack: 5.79.0(webpack-cli@5.0.1)
+
+  /terser@5.16.9:
+    resolution: {integrity: sha512-HPa/FdTB9XGI2H1/keLFZHxl6WNvAI4YalHGtDQTlMnJcoqSab1UwL4l1hGEhs6/GmLHBZIg/YgB++jcbzoOEg==}
+    engines: {node: '>=10'}
+    hasBin: true
+    dependencies:
+      '@jridgewell/source-map': 0.3.3
+      acorn: 8.8.2
+      commander: 2.20.3
+      source-map-support: 0.5.21
 
   /test-exclude@6.0.0:
     resolution: {integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==}
@@ -7726,7 +8229,6 @@ packages:
 
   /tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
-    dev: false
 
   /trim-newlines@3.0.1:
     resolution: {integrity: sha512-c1PTsA3tYrIsLGkJkzHF+w9F2EyxfXGo4UyJc4pFL++FMjnq0HJS69T3M7d//gKrFKwy429bouPescbjecU+Zw==}
@@ -7748,7 +8250,6 @@ packages:
 
   /tslib@2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
-    dev: false
 
   /tsm@2.3.0:
     resolution: {integrity: sha512-++0HFnmmR+gMpDtKTnW3XJ4yv9kVGi20n+NfyQWB9qwJvTaIWY9kBmzek2YUQK5APTQ/1DTrXmm4QtFPmW9Rzw==}
@@ -8071,6 +8572,11 @@ packages:
       core-util-is: 1.0.2
       extsprintf: 1.3.0
 
+  /virtual-resource-loader@1.0.1:
+    resolution: {integrity: sha512-LAsQQv2oI9hOjSlwfZj5UzY3AmR05GNd+hhWi8Yg+wvISMDH4JEr69mCP2IQckl2hBGm0KA2Tq2pOPAa0nQJCA==}
+    dependencies:
+      loader-utils: 2.0.4
+
   /vite-node@0.30.1(@types/node@18.11.17):
     resolution: {integrity: sha512-vTikpU/J7e6LU/8iM3dzBo8ZhEiKZEKRznEMm+mJh95XhWaPrJQraT/QsT2NWmuEf+zgAoMe64PKT7hfZ1Njmg==}
     engines: {node: '>=v14.18.0'}
@@ -8204,6 +8710,13 @@ packages:
       loose-envify: 1.4.0
     dev: false
 
+  /watchpack@2.4.0:
+    resolution: {integrity: sha512-Lcvm7MGST/4fup+ifyKi2hjyIAwcdI4HRgtvTpIUxBRhB+RFtUh8XtDOxUfctVCnhVi+QQj49i91OyvzkJl6cg==}
+    engines: {node: '>=10.13.0'}
+    dependencies:
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.10
+
   /wcwidth@1.0.1:
     resolution: {integrity: sha512-XHPEwS0q6TaxcvG85+8EYkbiCux2XtWG2mkc47Ng2A77BQu9+DqIOJldST4HgPkuea7dvKSj5VgX3P1d4rW8Tg==}
     dependencies:
@@ -8212,7 +8725,89 @@ packages:
 
   /webidl-conversions@3.0.1:
     resolution: {integrity: sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==}
-    dev: false
+
+  /webpack-cli@5.0.1(webpack@5.79.0):
+    resolution: {integrity: sha512-S3KVAyfwUqr0Mo/ur3NzIp6jnerNpo7GUO6so51mxLi1spqsA17YcMXy0WOIJtBSnj748lthxC6XLbNKh/ZC+A==}
+    engines: {node: '>=14.15.0'}
+    hasBin: true
+    peerDependencies:
+      '@webpack-cli/generators': '*'
+      webpack: 5.x.x
+      webpack-bundle-analyzer: '*'
+      webpack-dev-server: '*'
+    peerDependenciesMeta:
+      '@webpack-cli/generators':
+        optional: true
+      webpack-bundle-analyzer:
+        optional: true
+      webpack-dev-server:
+        optional: true
+    dependencies:
+      '@discoveryjs/json-ext': 0.5.7
+      '@webpack-cli/configtest': 2.0.1(webpack-cli@5.0.1)(webpack@5.79.0)
+      '@webpack-cli/info': 2.0.1(webpack-cli@5.0.1)(webpack@5.79.0)
+      '@webpack-cli/serve': 2.0.1(webpack-cli@5.0.1)(webpack@5.79.0)
+      colorette: 2.0.19
+      commander: 9.5.0
+      cross-spawn: 7.0.3
+      envinfo: 7.8.1
+      fastest-levenshtein: 1.0.16
+      import-local: 3.1.0
+      interpret: 3.1.1
+      rechoir: 0.8.0
+      webpack: 5.79.0(webpack-cli@5.0.1)
+      webpack-merge: 5.8.0
+
+  /webpack-merge@5.8.0:
+    resolution: {integrity: sha512-/SaI7xY0831XwP6kzuwhKWVKDP9t1QY1h65lAFLbZqMPIuYcD9QAW4u9STIbU9kaJbPBB/geU/gLr1wDjOhQ+Q==}
+    engines: {node: '>=10.0.0'}
+    dependencies:
+      clone-deep: 4.0.1
+      wildcard: 2.0.0
+
+  /webpack-sources@3.2.3:
+    resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
+    engines: {node: '>=10.13.0'}
+
+  /webpack@5.79.0(webpack-cli@5.0.1):
+    resolution: {integrity: sha512-3mN4rR2Xq+INd6NnYuL9RC9GAmc1ROPKJoHhrZ4pAjdMFEkJJWrsPw8o2JjCIyQyTu7rTXYn4VG6OpyB3CobZg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+    peerDependencies:
+      webpack-cli: '*'
+    peerDependenciesMeta:
+      webpack-cli:
+        optional: true
+    dependencies:
+      '@types/eslint-scope': 3.7.4
+      '@types/estree': 1.0.0
+      '@webassemblyjs/ast': 1.11.1
+      '@webassemblyjs/wasm-edit': 1.11.1
+      '@webassemblyjs/wasm-parser': 1.11.1
+      acorn: 8.8.2
+      acorn-import-assertions: 1.8.0(acorn@8.8.2)
+      browserslist: 4.21.3
+      chrome-trace-event: 1.0.3
+      enhanced-resolve: 5.12.0
+      es-module-lexer: 1.2.1
+      eslint-scope: 5.1.1
+      events: 3.3.0
+      glob-to-regexp: 0.4.1
+      graceful-fs: 4.2.10
+      json-parse-even-better-errors: 2.3.1
+      loader-runner: 4.3.0
+      mime-types: 2.1.35
+      neo-async: 2.6.2
+      schema-utils: 3.1.1
+      tapable: 2.2.1
+      terser-webpack-plugin: 5.3.7(webpack@5.79.0)
+      watchpack: 2.4.0
+      webpack-cli: 5.0.1(webpack@5.79.0)
+      webpack-sources: 3.2.3
+    transitivePeerDependencies:
+      - '@swc/core'
+      - esbuild
+      - uglify-js
 
   /well-known-symbols@2.0.0:
     resolution: {integrity: sha512-ZMjC3ho+KXo0BfJb7JgtQ5IBuvnShdlACNkKkdsqBmYw3bPAaJfPeYUo6tLUaT5tG/Gkh7xkpBhKRQ9e7pyg9Q==}
@@ -8224,7 +8819,6 @@ packages:
     dependencies:
       tr46: 0.0.3
       webidl-conversions: 3.0.1
-    dev: false
 
   /which-boxed-primitive@1.0.2:
     resolution: {integrity: sha512-bwZdv0AKLpplFY2KZRX6TvyuN7ojjr7lwkg6ml0roIy9YeuSr7JS372qlNW18UQYzgYK9ziGcerWqZOmEn9VNg==}
@@ -8271,7 +8865,6 @@ packages:
     hasBin: true
     dependencies:
       isexe: 2.0.0
-    dev: false
 
   /why-is-node-running@2.2.2:
     resolution: {integrity: sha512-6tSwToZxTOcotxHeA+qGCq1mVzKR3CwcJGmVcY+QE8SHy6TnpFnh8PAvPNHYr7EcuVeG0QSMxtYCuO1ta/G/oA==}
@@ -8288,6 +8881,9 @@ packages:
     dependencies:
       string-width: 4.2.3
     dev: false
+
+  /wildcard@2.0.0:
+    resolution: {integrity: sha512-JcKqAHLPxcdb9KM49dufGXn2x3ssnfjbcaQdLlfZsL9rH9wgDQjUtDxbo8NE0F6SFvydeu1VhZe7hZuHsB2/pw==}
 
   /wireit@0.9.5:
     resolution: {integrity: sha512-dKKNAwLxQjbPPMrltPxMUFKvLy2z6hlVjvR/qitvPm8GEQyb/1QYBG7ObvOQLsi95uAXpkWLJXBYkCKeVcMVgA==}
@@ -8329,7 +8925,6 @@ packages:
       ansi-styles: 4.3.0
       string-width: 4.2.3
       strip-ansi: 6.0.1
-    dev: false
 
   /wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
@@ -8365,7 +8960,6 @@ packages:
   /y18n@5.0.8:
     resolution: {integrity: sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==}
     engines: {node: '>=10'}
-    dev: false
 
   /yallist@2.1.2:
     resolution: {integrity: sha512-ncTzHV7NvsQZkYe1DW7cbDLm0YpzHmZF5r/iyP3ZnQtMiJ+pjzisCiMNI+Sj+xQF5pXhSHxSB3uDbsBTzY/c2A==}
@@ -8390,6 +8984,11 @@ packages:
       camelcase: 5.3.1
       decamelize: 1.2.0
     dev: false
+
+  /yargs-parser@20.2.9:
+    resolution: {integrity: sha512-y11nGElTIV+CT3Zv9t7VKl+Q3hTQoT9a1Qzezhhl6Rp21gJ/IVTW7Z3y9EWXhuUBC2Shnf+DX0antecpAwSP8w==}
+    engines: {node: '>=10'}
+    dev: true
 
   /yargs-parser@21.1.1:
     resolution: {integrity: sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==}
@@ -8434,6 +9033,19 @@ packages:
       yargs-parser: 18.1.3
     dev: false
 
+  /yargs@16.2.0:
+    resolution: {integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==}
+    engines: {node: '>=10'}
+    dependencies:
+      cliui: 7.0.4
+      escalade: 3.1.1
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      string-width: 4.2.3
+      y18n: 5.0.8
+      yargs-parser: 20.2.9
+    dev: true
+
   /yargs@17.6.2:
     resolution: {integrity: sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==}
     engines: {node: '>=12'}
@@ -8450,7 +9062,6 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
-    dev: false
 
   /yocto-queue@1.0.0:
     resolution: {integrity: sha512-9bnSc/HEW2uRy67wc+T8UwauLuPJVn28jb+GtJY16iiKWyvmYJRXVT4UamsAEGQfPohgr2q4Tq0sQbQlxTfi1g==}

--- a/tests/__snapshots__/package/esm-compat/dist/index.ts.snap
+++ b/tests/__snapshots__/package/esm-compat/dist/index.ts.snap
@@ -13,7 +13,6 @@ const reactKeyedFlattenChildren__default = /* @__PURE__ */ _interopDefaultCompat
 const subpath__default = /* @__PURE__ */ _interopDefaultCompat(subpath);
 const index_js__default$1 = /* @__PURE__ */ _interopDefaultCompat(index_js$1);
 const ReactDOM__default = /* @__PURE__ */ _interopDefaultCompat(ReactDOM);
-const index = {};
 const App = () => /* @__PURE__ */ jsxRuntime_js.jsx("div", { children: "App" });
 const render = () => ReactDOM__default.default.renderToStaticMarkup(/* @__PURE__ */ jsxRuntime_js.jsx(App, {}));
 Object.defineProperty(exports, "cjsDirIndex", {
@@ -34,7 +33,6 @@ Object.defineProperty(exports, "scopedPatchedSubpath", {
 });
 exports.App = App;
 exports.render = render;
-exports.translations = index;
 /* #endregion */
 
 
@@ -45,12 +43,10 @@ export { default as scopedSubpath } from '@crackle-fixtures/dep-with-exports/sub
 export { default as scopedPatchedSubpath } from '@crackle-fixtures/dep-with-exports-always-patch/subpath';
 import React from 'react';
 
-declare const _default: {};
-
 declare const App: React.FC;
 declare const render: () => string;
 
-export { App, render, _default as translations };
+export { App, render };
 /* #endregion */
 
 
@@ -61,7 +57,6 @@ import { default as default4 } from "@crackle-fixtures/dep-with-exports/subpath"
 import { default as default5 } from "@crackle-fixtures/dep-with-exports-always-patch/index.js";
 import { jsx } from "react/jsx-runtime.js";
 import ReactDOM from "react-dom/server.node.js";
-const index = {};
 const App = () => /* @__PURE__ */ jsx("div", { children: "App" });
 const render = () => ReactDOM.renderToStaticMarkup(/* @__PURE__ */ jsx(App, {}));
 export {
@@ -70,7 +65,6 @@ export {
   default3 as cjsFauxEsm,
   render,
   default5 as scopedPatchedSubpath,
-  default4 as scopedSubpath,
-  index as translations
+  default4 as scopedSubpath
 };
 /* #endregion */

--- a/tests/__snapshots__/package/with-vocab/dist/client.vocab/fr.translations.json.snap
+++ b/tests/__snapshots__/package/with-vocab/dist/client.vocab/fr.translations.json.snap
@@ -1,0 +1,10 @@
+/* #region dist/client.vocab/fr.translations.json */
+{
+  "specialCharacters - '‘’“”\"!@#$%^&*()_+\\/`~\\\\": {
+    "message": "‘’“”'\"!@#$%^&*()_+\\/`~\\\\"
+  },
+  "vocabPublishDate": {
+    "message": "Vocab a été publié le {publishDate, date, medium}"
+  }
+}
+/* #endregion */

--- a/tests/__snapshots__/package/with-vocab/dist/client.vocab/index.ts.snap
+++ b/tests/__snapshots__/package/with-vocab/dist/client.vocab/index.ts.snap
@@ -1,0 +1,33 @@
+/* #region dist/client.vocab/index.cjs */
+"use strict";
+const runtime = require("@vocab/core/runtime");
+const translations = runtime.createTranslationFile({
+  en: runtime.createLanguage({
+    "specialCharacters - '‘’“”\"!@#$%^&*()_+\\/`~\\\\": "‘’“”'\"!@#$%^&*()_+\\/`~\\\\",
+    vocabPublishDate: "<strong>Vocab</strong> was published on {publishDate, date, small}"
+  }),
+  fr: runtime.createLanguage({
+    "specialCharacters - '‘’“”\"!@#$%^&*()_+\\/`~\\\\": "‘’“”'\"!@#$%^&*()_+\\/`~\\\\",
+    vocabPublishDate: "Vocab a été publié le {publishDate, date, medium}"
+  })
+});
+exports.translations = translations;
+/* #endregion */
+
+
+/* #region dist/client.vocab/index.mjs */
+import { createTranslationFile, createLanguage } from "@vocab/core/runtime";
+const translations = createTranslationFile({
+  en: createLanguage({
+    "specialCharacters - '‘’“”\"!@#$%^&*()_+\\/`~\\\\": "‘’“”'\"!@#$%^&*()_+\\/`~\\\\",
+    vocabPublishDate: "<strong>Vocab</strong> was published on {publishDate, date, small}"
+  }),
+  fr: createLanguage({
+    "specialCharacters - '‘’“”\"!@#$%^&*()_+\\/`~\\\\": "‘’“”'\"!@#$%^&*()_+\\/`~\\\\",
+    vocabPublishDate: "Vocab a été publié le {publishDate, date, medium}"
+  })
+});
+export {
+  translations
+};
+/* #endregion */

--- a/tests/__snapshots__/package/with-vocab/dist/client.vocab/translations.json.snap
+++ b/tests/__snapshots__/package/with-vocab/dist/client.vocab/translations.json.snap
@@ -1,0 +1,10 @@
+/* #region dist/client.vocab/translations.json */
+{
+  "specialCharacters - '‘’“”\"!@#$%^&*()_+\\/`~\\\\": {
+    "message": "‘’“”'\"!@#$%^&*()_+\\/`~\\\\"
+  },
+  "vocabPublishDate": {
+    "message": "<strong>Vocab</strong> was published on {publishDate, date, small}"
+  }
+}
+/* #endregion */

--- a/tests/__snapshots__/package/with-vocab/dist/index.ts.snap
+++ b/tests/__snapshots__/package/with-vocab/dist/index.ts.snap
@@ -78,12 +78,12 @@ function useTranslations(translations) {
 }
 function Content() {
   const common = useTranslations(_vocab_index_cjs.translations);
-  const client = useTranslations(client_vocab_index_cjs.translations);
+  const client2 = useTranslations(client_vocab_index_cjs.translations);
   const message = `${common.t("hello")} ${common.t("world")}`;
-  const specialCharacterResult = client.t(
+  const specialCharacterResult = client2.t(
     "specialCharacters - '‘’“”\"!@#$%^&*()_+\\/`~\\\\"
   );
-  const vocabPublishNode = client.t("vocabPublishDate", {
+  const vocabPublishNode = client2.t("vocabPublishDate", {
     publishDate: 1605847714e3,
     strong: (children) => /* @__PURE__ */ jsxRuntime.jsx("strong", { children })
   });
@@ -131,18 +131,22 @@ function App({ children }) {
     ) : null
   ] });
 }
-const node = document.createElement("div");
-document.body.appendChild(node);
-reactDom.render(
-  /* @__PURE__ */ jsxRuntime.jsx(App, { children: /* @__PURE__ */ jsxRuntime.jsx(Content, {}) }),
-  node
-);
+const client = () => {
+  const node = document.createElement("div");
+  document.body.appendChild(node);
+  reactDom.render(
+    /* @__PURE__ */ jsxRuntime.jsx(App, { children: /* @__PURE__ */ jsxRuntime.jsx(Content, {}) }),
+    node
+  );
+};
+module.exports = client;
 /* #endregion */
 
 
 /* #region dist/index.d.ts */
+declare const _default: () => void;
 
-export { }
+export { _default as default };
 /* #endregion */
 
 
@@ -223,12 +227,12 @@ function useTranslations(translations2) {
 }
 function Content() {
   const common = useTranslations(translations);
-  const client = useTranslations(translations$1);
+  const client2 = useTranslations(translations$1);
   const message = `${common.t("hello")} ${common.t("world")}`;
-  const specialCharacterResult = client.t(
+  const specialCharacterResult = client2.t(
     "specialCharacters - '‘’“”\"!@#$%^&*()_+\\/`~\\\\"
   );
-  const vocabPublishNode = client.t("vocabPublishDate", {
+  const vocabPublishNode = client2.t("vocabPublishDate", {
     publishDate: 1605847714e3,
     strong: (children) => /* @__PURE__ */ jsx("strong", { children })
   });
@@ -276,10 +280,15 @@ function App({ children }) {
     ) : null
   ] });
 }
-const node = document.createElement("div");
-document.body.appendChild(node);
-render(
-  /* @__PURE__ */ jsx(App, { children: /* @__PURE__ */ jsx(Content, {}) }),
-  node
-);
+const client = () => {
+  const node = document.createElement("div");
+  document.body.appendChild(node);
+  render(
+    /* @__PURE__ */ jsx(App, { children: /* @__PURE__ */ jsx(Content, {}) }),
+    node
+  );
+};
+export {
+  client as default
+};
 /* #endregion */

--- a/tests/__snapshots__/package/with-vocab/dist/index.ts.snap
+++ b/tests/__snapshots__/package/with-vocab/dist/index.ts.snap
@@ -78,6 +78,11 @@ function useTranslations(translations) {
 }
 function Content() {
   const common = useTranslations(_vocab_index_cjs.translations);
+  const message = `${common.t("hello")} ${common.t("world")}`;
+  return /* @__PURE__ */ jsxRuntime.jsx(jsxRuntime.Fragment, { children: /* @__PURE__ */ jsxRuntime.jsx("div", { id: "message", children: message }) });
+}
+function AllContent() {
+  const common = useTranslations(_vocab_index_cjs.translations);
   const client2 = useTranslations(client_vocab_index_cjs.translations);
   const message = `${common.t("hello")} ${common.t("world")}`;
   const specialCharacterResult = client2.t(
@@ -135,7 +140,10 @@ const client = () => {
   const node = document.createElement("div");
   document.body.appendChild(node);
   reactDom.render(
-    /* @__PURE__ */ jsxRuntime.jsx(App, { children: /* @__PURE__ */ jsxRuntime.jsx(Content, {}) }),
+    /* @__PURE__ */ jsxRuntime.jsxs(App, { children: [
+      /* @__PURE__ */ jsxRuntime.jsx(AllContent, {}),
+      /* @__PURE__ */ jsxRuntime.jsx(Content, {})
+    ] }),
     node
   );
 };
@@ -151,7 +159,7 @@ export { _default as default };
 
 
 /* #region dist/index.mjs */
-import { jsx, jsxs, Fragment } from "react/jsx-runtime";
+import { jsx, Fragment, jsxs } from "react/jsx-runtime";
 import React, { useMemo, useReducer, useCallback, isValidElement, cloneElement, useContext, useState } from "react";
 import { render } from "react-dom";
 import { translations } from "./.vocab/index.mjs";
@@ -227,6 +235,11 @@ function useTranslations(translations2) {
 }
 function Content() {
   const common = useTranslations(translations);
+  const message = `${common.t("hello")} ${common.t("world")}`;
+  return /* @__PURE__ */ jsx(Fragment, { children: /* @__PURE__ */ jsx("div", { id: "message", children: message }) });
+}
+function AllContent() {
+  const common = useTranslations(translations);
   const client2 = useTranslations(translations$1);
   const message = `${common.t("hello")} ${common.t("world")}`;
   const specialCharacterResult = client2.t(
@@ -284,7 +297,10 @@ const client = () => {
   const node = document.createElement("div");
   document.body.appendChild(node);
   render(
-    /* @__PURE__ */ jsx(App, { children: /* @__PURE__ */ jsx(Content, {}) }),
+    /* @__PURE__ */ jsxs(App, { children: [
+      /* @__PURE__ */ jsx(AllContent, {}),
+      /* @__PURE__ */ jsx(Content, {})
+    ] }),
     node
   );
 };

--- a/tests/__snapshots__/package/with-vocab/dist/index.ts.snap
+++ b/tests/__snapshots__/package/with-vocab/dist/index.ts.snap
@@ -1,0 +1,285 @@
+/* #region dist/index.cjs */
+"use strict";
+const jsxRuntime = require("react/jsx-runtime");
+const React = require("react");
+const reactDom = require("react-dom");
+const _vocab_index_cjs = require("./.vocab/index.cjs");
+const client_vocab_index_cjs = require("./client.vocab/index.cjs");
+const _interopDefaultCompat = (e) => e && typeof e === "object" && "default" in e ? e : { default: e };
+const React__default = /* @__PURE__ */ _interopDefaultCompat(React);
+const TranslationsContext = /* @__PURE__ */ React__default.default.createContext(void 0);
+const VocabProvider = ({
+  children,
+  language,
+  locale
+}) => {
+  const value = React.useMemo(() => ({
+    language,
+    locale
+  }), [language, locale]);
+  return /* @__PURE__ */ React__default.default.createElement(TranslationsContext.Provider, {
+    value
+  }, children);
+};
+const useLanguage = () => {
+  const context = React.useContext(TranslationsContext);
+  if (!context) {
+    throw new Error("Attempted to access translation without Vocab context set. Did you forget to render VocabProvider?");
+  }
+  if (!context.language) {
+    throw new Error("Attempted to access translation without language set. Did you forget to pass language to VocabProvider?");
+  }
+  return context;
+};
+const SERVER_RENDERING = typeof window === "undefined";
+function useTranslations(translations) {
+  const {
+    language,
+    locale
+  } = useLanguage();
+  const [, forceRender] = React.useReducer((s) => s + 1, 0);
+  const translationsObject = translations.getLoadedMessages(language, locale || language);
+  let ready = true;
+  if (!translationsObject) {
+    if (SERVER_RENDERING) {
+      throw new Error(`Translations not synchronously available on server render. Applying translations dynamically server-side is not supported.`);
+    }
+    translations.load(language).then(() => {
+      forceRender();
+    });
+    ready = false;
+  }
+  const t = React.useCallback((key, params) => {
+    if (!translationsObject) {
+      return " ";
+    }
+    const message = translationsObject === null || translationsObject === void 0 ? void 0 : translationsObject[key];
+    if (!message) {
+      console.error(`Unable to find translation for key "${key}". Possible keys are ${Object.keys(translationsObject).map((v) => `"${v}"`).join(", ")}`);
+      return "";
+    }
+    const result = message.format(params);
+    if (Array.isArray(result)) {
+      for (let i = 0; i < result.length; i++) {
+        const item = result[i];
+        if (typeof item === "object" && item && !item.key && /* @__PURE__ */ React.isValidElement(item)) {
+          result[i] = /* @__PURE__ */ React.cloneElement(item, {
+            key: `_vocab-${i}`
+          });
+        }
+      }
+    }
+    return result;
+  }, [translationsObject]);
+  return {
+    ready,
+    t
+  };
+}
+function Content() {
+  const common = useTranslations(_vocab_index_cjs.translations);
+  const client = useTranslations(client_vocab_index_cjs.translations);
+  const message = `${common.t("hello")} ${common.t("world")}`;
+  const specialCharacterResult = client.t(
+    "specialCharacters - '‘’“”\"!@#$%^&*()_+\\/`~\\\\"
+  );
+  const vocabPublishNode = client.t("vocabPublishDate", {
+    publishDate: 1605847714e3,
+    strong: (children) => /* @__PURE__ */ jsxRuntime.jsx("strong", { children })
+  });
+  return /* @__PURE__ */ jsxRuntime.jsxs(jsxRuntime.Fragment, { children: [
+    /* @__PURE__ */ jsxRuntime.jsx("div", { id: "message", children: message }),
+    /* @__PURE__ */ jsxRuntime.jsx("div", { id: "publish-date", children: vocabPublishNode }),
+    /* @__PURE__ */ jsxRuntime.jsxs("div", { id: "special-characters", children: [
+      "Special Characters: ",
+      specialCharacterResult
+    ] })
+  ] });
+}
+function App({ children }) {
+  const [lang, setLang] = React.useState("en");
+  const [locale, setLocale] = React.useState("en-AU");
+  const theLocale = lang === "en" ? locale : void 0;
+  return /* @__PURE__ */ jsxRuntime.jsxs(VocabProvider, { language: lang, locale: theLocale, children: [
+    children,
+    /* @__PURE__ */ jsxRuntime.jsx("label", { htmlFor: "languages", children: "Language:" }),
+    /* @__PURE__ */ jsxRuntime.jsxs(
+      "select",
+      {
+        name: "languages",
+        id: "language-select",
+        onChange: (event) => {
+          setLang(event.currentTarget.value);
+        },
+        children: [
+          /* @__PURE__ */ jsxRuntime.jsx("option", { value: "en", children: "en" }),
+          /* @__PURE__ */ jsxRuntime.jsx("option", { value: "fr", children: "fr" }),
+          /* @__PURE__ */ jsxRuntime.jsx("option", { value: "pseudo", children: "pseudo" })
+        ]
+      }
+    ),
+    lang === "en" ? /* @__PURE__ */ jsxRuntime.jsxs(
+      "button",
+      {
+        id: "toggle-locale",
+        onClick: () => setLocale((curr) => curr === "en-AU" ? "en-US" : "en-AU"),
+        children: [
+          "Toggle locale: ",
+          locale
+        ]
+      }
+    ) : null
+  ] });
+}
+const node = document.createElement("div");
+document.body.appendChild(node);
+reactDom.render(
+  /* @__PURE__ */ jsxRuntime.jsx(App, { children: /* @__PURE__ */ jsxRuntime.jsx(Content, {}) }),
+  node
+);
+/* #endregion */
+
+
+/* #region dist/index.d.ts */
+
+export { }
+/* #endregion */
+
+
+/* #region dist/index.mjs */
+import { jsx, jsxs, Fragment } from "react/jsx-runtime";
+import React, { useMemo, useReducer, useCallback, isValidElement, cloneElement, useContext, useState } from "react";
+import { render } from "react-dom";
+import { translations } from "./.vocab/index.mjs";
+import { translations as translations$1 } from "./client.vocab/index.mjs";
+const TranslationsContext = /* @__PURE__ */ React.createContext(void 0);
+const VocabProvider = ({
+  children,
+  language,
+  locale
+}) => {
+  const value = useMemo(() => ({
+    language,
+    locale
+  }), [language, locale]);
+  return /* @__PURE__ */ React.createElement(TranslationsContext.Provider, {
+    value
+  }, children);
+};
+const useLanguage = () => {
+  const context = useContext(TranslationsContext);
+  if (!context) {
+    throw new Error("Attempted to access translation without Vocab context set. Did you forget to render VocabProvider?");
+  }
+  if (!context.language) {
+    throw new Error("Attempted to access translation without language set. Did you forget to pass language to VocabProvider?");
+  }
+  return context;
+};
+const SERVER_RENDERING = typeof window === "undefined";
+function useTranslations(translations2) {
+  const {
+    language,
+    locale
+  } = useLanguage();
+  const [, forceRender] = useReducer((s) => s + 1, 0);
+  const translationsObject = translations2.getLoadedMessages(language, locale || language);
+  let ready = true;
+  if (!translationsObject) {
+    if (SERVER_RENDERING) {
+      throw new Error(`Translations not synchronously available on server render. Applying translations dynamically server-side is not supported.`);
+    }
+    translations2.load(language).then(() => {
+      forceRender();
+    });
+    ready = false;
+  }
+  const t = useCallback((key, params) => {
+    if (!translationsObject) {
+      return " ";
+    }
+    const message = translationsObject === null || translationsObject === void 0 ? void 0 : translationsObject[key];
+    if (!message) {
+      console.error(`Unable to find translation for key "${key}". Possible keys are ${Object.keys(translationsObject).map((v) => `"${v}"`).join(", ")}`);
+      return "";
+    }
+    const result = message.format(params);
+    if (Array.isArray(result)) {
+      for (let i = 0; i < result.length; i++) {
+        const item = result[i];
+        if (typeof item === "object" && item && !item.key && /* @__PURE__ */ isValidElement(item)) {
+          result[i] = /* @__PURE__ */ cloneElement(item, {
+            key: `_vocab-${i}`
+          });
+        }
+      }
+    }
+    return result;
+  }, [translationsObject]);
+  return {
+    ready,
+    t
+  };
+}
+function Content() {
+  const common = useTranslations(translations);
+  const client = useTranslations(translations$1);
+  const message = `${common.t("hello")} ${common.t("world")}`;
+  const specialCharacterResult = client.t(
+    "specialCharacters - '‘’“”\"!@#$%^&*()_+\\/`~\\\\"
+  );
+  const vocabPublishNode = client.t("vocabPublishDate", {
+    publishDate: 1605847714e3,
+    strong: (children) => /* @__PURE__ */ jsx("strong", { children })
+  });
+  return /* @__PURE__ */ jsxs(Fragment, { children: [
+    /* @__PURE__ */ jsx("div", { id: "message", children: message }),
+    /* @__PURE__ */ jsx("div", { id: "publish-date", children: vocabPublishNode }),
+    /* @__PURE__ */ jsxs("div", { id: "special-characters", children: [
+      "Special Characters: ",
+      specialCharacterResult
+    ] })
+  ] });
+}
+function App({ children }) {
+  const [lang, setLang] = useState("en");
+  const [locale, setLocale] = useState("en-AU");
+  const theLocale = lang === "en" ? locale : void 0;
+  return /* @__PURE__ */ jsxs(VocabProvider, { language: lang, locale: theLocale, children: [
+    children,
+    /* @__PURE__ */ jsx("label", { htmlFor: "languages", children: "Language:" }),
+    /* @__PURE__ */ jsxs(
+      "select",
+      {
+        name: "languages",
+        id: "language-select",
+        onChange: (event) => {
+          setLang(event.currentTarget.value);
+        },
+        children: [
+          /* @__PURE__ */ jsx("option", { value: "en", children: "en" }),
+          /* @__PURE__ */ jsx("option", { value: "fr", children: "fr" }),
+          /* @__PURE__ */ jsx("option", { value: "pseudo", children: "pseudo" })
+        ]
+      }
+    ),
+    lang === "en" ? /* @__PURE__ */ jsxs(
+      "button",
+      {
+        id: "toggle-locale",
+        onClick: () => setLocale((curr) => curr === "en-AU" ? "en-US" : "en-AU"),
+        children: [
+          "Toggle locale: ",
+          locale
+        ]
+      }
+    ) : null
+  ] });
+}
+const node = document.createElement("div");
+document.body.appendChild(node);
+render(
+  /* @__PURE__ */ jsx(App, { children: /* @__PURE__ */ jsx(Content, {}) }),
+  node
+);
+/* #endregion */

--- a/tests/package.test.ts
+++ b/tests/package.test.ts
@@ -19,6 +19,7 @@ test.each([
   'with-dep-hidden-package-json',
   'with-graphql-schema-types',
   'with-side-effects',
+  'with-vocab',
 ])(
   'fixture %s',
   async (fixtureName) => {

--- a/tests/shapshot-output.ts
+++ b/tests/shapshot-output.ts
@@ -23,7 +23,7 @@ export default async function snapshotOutput(
     onlyFiles: true,
   });
   const groups = _.groupBy(distFiles, (fileName) =>
-    fileName.replace(/(.cjs|.mjs|.d.ts)$/, ''),
+    fileName.replace(/(.cjs|.mjs|.d.ts)$/, '.ts'),
   );
 
   await promiseMap(Object.entries(groups), async ([groupName, files]) => {
@@ -34,7 +34,7 @@ export default async function snapshotOutput(
 
     const snapshotDir = `__snapshots__/${suiteName}/${fixtureName}`;
     await expect(bundle.join('\n\n')).toMatchFileSnapshot(
-      `${snapshotDir}/${groupName}.ts.snap`,
+      `${snapshotDir}/${groupName}.snap`,
     );
   });
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -5,6 +5,7 @@
     "declaration": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
+    "resolveJsonModule": true,
     "allowSyntheticDefaultImports": true,
     "isolatedModules": true,
     "noUnusedLocals": true,


### PR DESCRIPTION
Crackle now produces an output that is compatible with the Vocab Webpack plugin.
When packaging, Crackle will ensure that the `translation.json` files are present in the output directory, next to the compiled translation files.
This allows the Vocab Webpack plugin to still work with compiled (CJS/ESM) translation files.

`@vocab/webpack/loader` requires a fix implemented in https://github.com/seek-oss/vocab/pull/141. This PR uses a snapshot version that will be updated to the final version once https://github.com/seek-oss/vocab/pull/141 is merged.

This PR will be merged after #103. Once #103 is merged the target branch will be [automatically](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/about-branches#working-with-branches) switched to `master`.