### PR TITLE
`crackle dev`: add `--webpack` CLI argument and `webpack` config option

### DIFF
--- a/.changeset/clever-apes-eat.md
+++ b/.changeset/clever-apes-eat.md
@@ -1,0 +1,5 @@
+---
+'@crackle/cli': minor
+---
+
+Added a `--webpack` option to `crackle dev` which generates Webpack-compatible shims.

--- a/.changeset/clever-apes-eat2.md
+++ b/.changeset/clever-apes-eat2.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': minor
+---
+
+Added a `webpack` config option which generates Webpack-compatible shims when `crackle dev` is run.

--- a/.changeset/loud-pans-sparkle.md
+++ b/.changeset/loud-pans-sparkle.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': patch
+---
+
+Fixed an issue with `crackle dev` not generating correct paths in dev entry points

--- a/.eslintignore
+++ b/.eslintignore
@@ -16,6 +16,11 @@ fixtures/dev-entries/dist
 # end managed by crackle
 
 # managed by crackle
+fixtures/dev-entries-webpack/cli
+fixtures/dev-entries-webpack/dist
+# end managed by crackle
+
+# managed by crackle
 fixtures/esm-compat/dist
 # end managed by crackle
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -19,6 +19,11 @@ fixtures/dev-entries/dist
 # end managed by crackle
 
 # managed by crackle
+fixtures/dev-entries-webpack/cli
+fixtures/dev-entries-webpack/dist
+# end managed by crackle
+
+# managed by crackle
 fixtures/esm-compat/dist
 # end managed by crackle
 

--- a/fixtures/dev-entries-webpack/.gitignore
+++ b/fixtures/dev-entries-webpack/.gitignore
@@ -1,0 +1,4 @@
+# managed by crackle
+/cli
+/dist
+# end managed by crackle

--- a/fixtures/dev-entries-webpack/package.json
+++ b/fixtures/dev-entries-webpack/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@crackle-fixtures/dev-entries-webpack",
+  "version": "1.0.0",
+  "private": true,
+  "license": "MIT",
+  "author": "SEEK",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./cli": {
+      "types": "./dist/cli.d.ts",
+      "import": "./dist/cli.mjs",
+      "require": "./dist/cli.cjs"
+    },
+    "./package.json": "./package.json"
+  },
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "files": [
+    "cli",
+    "dist"
+  ],
+  "scripts": {
+    "dev": "crackle dev --webpack",
+    "fix": "crackle fix",
+    "package": "crackle package"
+  },
+  "dependencies": {},
+  "devDependencies": {}
+}

--- a/fixtures/dev-entries-webpack/src/entries/cli.ts
+++ b/fixtures/dev-entries-webpack/src/entries/cli.ts
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.log('Hello, world!');

--- a/fixtures/dev-entries-webpack/src/index.ts
+++ b/fixtures/dev-entries-webpack/src/index.ts
@@ -1,0 +1,3 @@
+export const something = 'something';
+
+export default {};

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -121,12 +121,20 @@ yargs(process.argv.slice(2))
   .command({
     command: 'dev',
     describe: 'Generate entry points for local development',
-    handler: async () => {
+    builder: {
+      webpack: {
+        description: 'Generate Webpack-compatible shims',
+        type: 'boolean',
+      },
+    },
+    handler: async (overrides) => {
       const config = await resolveConfig();
       const { dev } = await import('@crackle/core/dev');
+
+      setConfigOverrides(config, overrides);
       await dev(config);
     },
-  })
+  } satisfies CommandModule<unknown, Pick<CrackleConfig, 'webpack'>>)
   .command({
     command: 'fix',
     describe: 'Fixes invalid project configuration',

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -17,6 +17,12 @@ export interface Config {
    */
   fix: boolean;
   /**
+   * Generate Webpack-compatible shims.
+   *
+   * @default false
+   */
+  webpack: boolean;
+  /**
    * Port for the server used in `start` and `serve`
    *
    * @default 5000
@@ -72,6 +78,7 @@ export type PartialConfig = Partial<Config>;
 export const defaultConfig: Config = {
   clean: true,
   fix: false,
+  webpack: false,
   port: 5000,
   publicPath: '/',
   root: process.cwd(),

--- a/packages/core/src/utils/dev-entry-points.ts
+++ b/packages/core/src/utils/dev-entry-points.ts
@@ -23,7 +23,7 @@ const configContext = new AsyncLocalStorage<EnhancedConfig>();
 
 const getHookLoader = async (entry: PackageEntryPoint, format: Format) => {
   const stringifyRelative = (p: string) =>
-    JSON.stringify(path.relative(entry.getOutputPath(format), p));
+    JSON.stringify(path.relative(entry.outputDir, p));
 
   const config = configContext.getStore();
   assert(config, 'config not set in context');

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,8 @@ importers:
 
   fixtures/dev-entries: {}
 
+  fixtures/dev-entries-webpack: {}
+
   fixtures/esm-compat:
     dependencies:
       '@crackle-fixtures/dep-with-exports':

--- a/tests/__snapshots__/dev/dev-entries-webpack/dist/cli.ts.snap
+++ b/tests/__snapshots__/dev/dev-entries-webpack/dist/cli.ts.snap
@@ -9,5 +9,5 @@ export * from "../src/entries/cli";
 
 
 /* #region dist/cli.mjs */
-export {}
+export {};
 /* #endregion */

--- a/tests/__snapshots__/dev/dev-entries-webpack/dist/cli.ts.snap
+++ b/tests/__snapshots__/dev/dev-entries-webpack/dist/cli.ts.snap
@@ -1,5 +1,5 @@
 /* #region dist/cli.cjs */
-module.exports = require("../fixtures/dev-entries-webpack/src/entries/cli.ts");
+module.exports = require("../src/entries/cli.ts");
 /* #endregion */
 
 

--- a/tests/__snapshots__/dev/dev-entries-webpack/dist/cli.ts.snap
+++ b/tests/__snapshots__/dev/dev-entries-webpack/dist/cli.ts.snap
@@ -1,0 +1,13 @@
+/* #region dist/cli.cjs */
+module.exports = require("../fixtures/dev-entries-webpack/src/entries/cli.ts");
+/* #endregion */
+
+
+/* #region dist/cli.d.ts */
+export * from "../src/entries/cli";
+/* #endregion */
+
+
+/* #region dist/cli.mjs */
+export {}
+/* #endregion */

--- a/tests/__snapshots__/dev/dev-entries-webpack/dist/index.ts.snap
+++ b/tests/__snapshots__/dev/dev-entries-webpack/dist/index.ts.snap
@@ -1,5 +1,5 @@
 /* #region dist/index.cjs */
-module.exports = require("../fixtures/dev-entries-webpack/src/index.ts");
+module.exports = require("../src/index.ts");
 /* #endregion */
 
 
@@ -10,7 +10,7 @@ export { default } from "../src/index";
 
 
 /* #region dist/index.mjs */
-const _mod = require("../fixtures/dev-entries-webpack/src/index.ts");
+const _mod = require("../src/index.ts");
 
 export const something = _mod.something;
 export default _mod.default;

--- a/tests/__snapshots__/dev/dev-entries-webpack/dist/index.ts.snap
+++ b/tests/__snapshots__/dev/dev-entries-webpack/dist/index.ts.snap
@@ -1,0 +1,17 @@
+/* #region dist/index.cjs */
+module.exports = require("../fixtures/dev-entries-webpack/src/index.ts");
+/* #endregion */
+
+
+/* #region dist/index.d.ts */
+export * from "../src/index";
+export { default } from "../src/index";
+/* #endregion */
+
+
+/* #region dist/index.mjs */
+const _mod = require("../fixtures/dev-entries-webpack/src/index.ts");
+
+export const something = _mod.something;
+export default _mod.default;
+/* #endregion */

--- a/tests/__snapshots__/dev/dev-entries/dist/cli.ts.snap
+++ b/tests/__snapshots__/dev/dev-entries/dist/cli.ts.snap
@@ -1,7 +1,7 @@
 /* #region dist/cli.cjs */
-require("../node_modules/.pnpm/tsm@2.3.0/node_modules/tsm/require.js");
+require("../../../node_modules/.pnpm/tsm@2.3.0/node_modules/tsm/require.js");
 
-module.exports = require("../fixtures/dev-entries/src/entries/cli.ts");
+module.exports = require("../src/entries/cli.ts");
 /* #endregion */
 
 
@@ -15,7 +15,7 @@ import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
 
-require("../node_modules/.pnpm/tsm@2.3.0/node_modules/tsm/require.js");
+require("../../../node_modules/.pnpm/tsm@2.3.0/node_modules/tsm/require.js");
 
 export {};
 /* #endregion */

--- a/tests/__snapshots__/dev/dev-entries/dist/cli.ts.snap
+++ b/tests/__snapshots__/dev/dev-entries/dist/cli.ts.snap
@@ -17,5 +17,5 @@ const require = createRequire(import.meta.url);
 
 require("../node_modules/.pnpm/tsm@2.3.0/node_modules/tsm/require.js");
 
-export {}
+export {};
 /* #endregion */

--- a/tests/__snapshots__/dev/dev-entries/dist/index.ts.snap
+++ b/tests/__snapshots__/dev/dev-entries/dist/index.ts.snap
@@ -1,7 +1,7 @@
 /* #region dist/index.cjs */
-require("../node_modules/.pnpm/tsm@2.3.0/node_modules/tsm/require.js");
+require("../../../node_modules/.pnpm/tsm@2.3.0/node_modules/tsm/require.js");
 
-module.exports = require("../fixtures/dev-entries/src/index.ts");
+module.exports = require("../src/index.ts");
 /* #endregion */
 
 
@@ -16,9 +16,9 @@ import { createRequire } from "module";
 
 const require = createRequire(import.meta.url);
 
-require("../node_modules/.pnpm/tsm@2.3.0/node_modules/tsm/require.js");
+require("../../../node_modules/.pnpm/tsm@2.3.0/node_modules/tsm/require.js");
 
-const _mod = require("../fixtures/dev-entries/src/index.ts");
+const _mod = require("../src/index.ts");
 
 export const something = _mod.something;
 export default _mod.default;

--- a/tests/dev.test.ts
+++ b/tests/dev.test.ts
@@ -11,13 +11,17 @@ beforeAll(() => {
   process.env.NODE_ENV = 'production';
 });
 
-test.each(['dev-entries'])(
-  'fixture %s',
-  async (fixtureName) => {
+test.each`
+  name                     | options
+  ${'dev-entries'}         | ${undefined}
+  ${'dev-entries-webpack'} | ${{ webpack: true }}
+`(
+  'fixture $name',
+  async ({ name: fixtureName, options }) => {
     const fixtureDir = f.find(fixtureName);
 
     const config = await resolveConfig({ cwd: fixtureDir });
-    await dev(config);
+    await dev({ ...config, ...options });
 
     await snapshotOutput('dev', fixtureName);
   },


### PR DESCRIPTION

Added a `--webpack` option to `crackle dev` which generates Webpack-compatible shims.

Added a `webpack` config option which generates Webpack-compatible shims when `crackle dev` is run.
