### PR TITLE
Run validate workflow on `push` and `pull_request`, but skip duplicate runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,7 @@
 name: CI
 
 on:
+  pull_request:
   push:
     branches:
       - '**'
@@ -15,8 +16,22 @@ env:
     packages/*/*/package.json
 
 jobs:
+  skip_check:
+    name: Check concurrent runs
+    runs-on: ubuntu-latest
+    outputs:
+      should_skip: ${{ steps.skip_check.outputs.should_skip }}
+    steps:
+      - uses: fkirc/skip-duplicate-actions@v5
+        id: skip_check
+        with:
+          concurrent_skipping: same_content_newer
+          cancel_others: true
+
   build:
     name: Build
+    needs: skip_check
+    if: needs.skip_check.outputs.should_skip != 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout & Install


### PR DESCRIPTION
Uses the same pattern as [Braid](https://github.com/seek-oss/braid-design-system/pull/1302) and [sku](https://github.com/seek-oss/sku/pull/812)