### PR TITLE
Use the new `preserveEntrySignatures` option recommended for libraries

### DIFF
--- a/.changeset/neat-turtles-press.md
+++ b/.changeset/neat-turtles-press.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': patch
+---
+
+Ensure DTS entries have the same exports as their source files

--- a/packages/core/src/package-utils/dts.ts
+++ b/packages/core/src/package-utils/dts.ts
@@ -25,6 +25,7 @@ export const createDtsBundle = async (
       if (log.code === 'EMPTY_BUNDLE') return false;
       defaultHandler(level, log);
     },
+    preserveEntrySignatures: 'strict',
   });
 
   await bundle.write({

--- a/tests/__snapshots__/package/with-side-effects/dist/css-more.ts.snap
+++ b/tests/__snapshots__/package/with-side-effects/dist/css-more.ts.snap
@@ -10,7 +10,18 @@ exports.Box = Box;
 
 
 /* #region dist/css-more.d.ts */
-export { Box, Breakpoint, breakpointNames, breakpoints } from './index.js';
+declare const breakpointNames: readonly ["mobile", "tablet", "desktop", "wide"];
+declare const breakpoints: {
+    readonly mobile: 0;
+    readonly tablet: 740;
+    readonly desktop: 992;
+    readonly wide: 1200;
+};
+type Breakpoint = keyof typeof breakpoints;
+
+declare const Box: () => null;
+
+export { Box, Breakpoint, breakpointNames, breakpoints };
 /* #endregion */
 
 

--- a/tests/__snapshots__/package/with-side-effects/dist/css.ts.snap
+++ b/tests/__snapshots__/package/with-side-effects/dist/css.ts.snap
@@ -7,7 +7,7 @@ exports.Box = cssMore.Box;
 
 
 /* #region dist/css.d.ts */
-export { Box } from './index.js';
+export { Box } from './css-more.js';
 /* #endregion */
 
 

--- a/tests/__snapshots__/package/with-side-effects/dist/index.ts.snap
+++ b/tests/__snapshots__/package/with-side-effects/dist/index.ts.snap
@@ -8,18 +8,8 @@ if (process.env.NODE_ENV === "development") {
 
 
 /* #region dist/index.d.ts */
-declare const breakpointNames: readonly ["mobile", "tablet", "desktop", "wide"];
-declare const breakpoints: {
-    readonly mobile: 0;
-    readonly tablet: 740;
-    readonly desktop: 992;
-    readonly wide: 1200;
-};
-type Breakpoint = keyof typeof breakpoints;
 
-declare const Box: () => null;
-
-export { Box, Breakpoint, breakpointNames, breakpoints };
+export { }
 /* #endregion */
 
 

--- a/tests/__snapshots__/package/with-side-effects/dist/reset.ts.snap
+++ b/tests/__snapshots__/package/with-side-effects/dist/reset.ts.snap
@@ -12,7 +12,7 @@ exports.breakpoints = styles_lib_breakpoints_cjs.breakpoints;
 
 
 /* #region dist/reset.d.ts */
-export { Breakpoint, breakpointNames, breakpoints } from './index.js';
+export { Breakpoint, breakpointNames, breakpoints } from './css-more.js';
 /* #endregion */
 
 


### PR DESCRIPTION
[Rollup 3.22.0](https://github.com/rollup/rollup/releases/tag/v3.22.0) made a few improvements to the chunking algorithm, and there's a new setting `preserveEntrySignatures` which is perfect for libraries. All the details are in https://github.com/rollup/rollup/pull/4989, but the TLDR is now we can specify that entry points don't add extra exports, and move those to a separate chunk.

[From the docs](https://rollupjs.org/configuration-options/#preserveentrysignatures):
> If set to `"strict"`, Rollup will create exactly the same exports in the entry chunk as there are in the corresponding entry module. If this is not possible because additional internal exports need to be added to a chunk, Rollup will instead create a "facade" entry chunk that reexports just the necessary bindings from other chunks but contains no code otherwise. This is the recommended setting for libraries.

This solves the problem in Braid where all internal and public exports were in `/reset` and every other entry re-exported from there.
