### PR TITLE
Add a `defineConfig` function

### DIFF
--- a/.changeset/cli-schools-sleep.md
+++ b/.changeset/cli-schools-sleep.md
@@ -1,0 +1,14 @@
+---
+'@crackle/cli': patch
+---
+
+Re-export `CrackleConfig` and `defineConfig` so that they can be used in `crackle.config.ts` without adding `@crackle/core` as a dependency
+
+```ts
+// crackle.config.ts
+import { defineConfig } from '@crackle/cli/config';
+
+export default defineConfig({
+  // ...
+});
+```

--- a/.changeset/core-falcons-join.md
+++ b/.changeset/core-falcons-join.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': patch
+---
+
+Export a `defineConfig` function to simplify typing the config object

--- a/.eslintignore
+++ b/.eslintignore
@@ -65,6 +65,7 @@ packages/babel-plugin-remove-exports/dist
 # end managed by crackle
 
 # managed by crackle
+packages/cli/config
 packages/cli/dist
 # end managed by crackle
 

--- a/.prettierignore
+++ b/.prettierignore
@@ -68,6 +68,7 @@ packages/babel-plugin-remove-exports/dist
 # end managed by crackle
 
 # managed by crackle
+packages/cli/config
 packages/cli/dist
 # end managed by crackle
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,18 @@ Here's how to specify a custom configuration file:
 
 ```ts
 // crackle.config.ts
-import type { CrackleConfig } from '@crackle/core';
+import { defineConfig } from '@crackle/cli/config';
+
+export default defineConfig({
+  // ...
+});
+```
+
+or
+
+```ts
+// crackle.config.ts
+import type { CrackleConfig } from '@crackle/cli/config';
 
 export default {
   // ...

--- a/docs/esm-reconciliation.md
+++ b/docs/esm-reconciliation.md
@@ -89,7 +89,7 @@ Crackle can be instructed to handle this via the `reconcileDependencies` option,
 
 ```ts
 // crackle.config.ts
-import type { CrackleConfig } from '@crackle/core';
+import type { CrackleConfig } from '@crackle/cli';
 
 export default {
   reconcileDependencies: {

--- a/fixtures/esm-compat/crackle.config.ts
+++ b/fixtures/esm-compat/crackle.config.ts
@@ -1,4 +1,4 @@
-import type { CrackleConfig } from '@crackle/core';
+import type { CrackleConfig } from '@crackle/cli/config';
 
 export default {
   reconcileDependencies: {

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@crackle/core": "workspace:*",
     "@playwright/test": "^1.32.0",
     "@preconstruct/eslint-plugin-format-js-tag": "^0.3.0",
-    "eslint": "^8.41.0",
+    "eslint": "^8.43.0",
     "eslint-config-seek": "^11.1.2",
     "ignore-sync": "^7.0.1",
     "prettier": "^2.8.8",

--- a/packages/cli/.gitignore
+++ b/packages/cli/.gitignore
@@ -1,3 +1,4 @@
 # managed by crackle
+/config
 /dist
 # end managed by crackle

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -9,6 +9,11 @@
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
+    "./config": {
+      "types": "./dist/config.d.ts",
+      "import": "./dist/config.mjs",
+      "require": "./dist/config.cjs"
+    },
     "./package.json": "./package.json"
   },
   "main": "./dist/index.cjs",
@@ -20,11 +25,12 @@
   "files": [
     "CHANGELOG.md",
     "bin.js",
+    "config",
     "dist"
   ],
   "scripts": {
-    "dev": "crackle dev",
-    "build": "crackle package"
+    "build": "crackle package",
+    "dev": "crackle dev"
   },
   "dependencies": {
     "@crackle/core": "^0.26.0",

--- a/packages/cli/src/entries/config.ts
+++ b/packages/cli/src/entries/config.ts
@@ -1,0 +1,1 @@
+export { type CrackleConfig, defineConfig } from '@crackle/core';

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -1,2 +1,7 @@
-export type { PartialConfig as CrackleConfig } from './config';
+import type { PartialConfig as CrackleConfig } from './config';
+
 export type { AppShell, CrackleServer } from './types';
+
+export type { CrackleConfig };
+
+export const defineConfig = (config: CrackleConfig) => config;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -32,13 +32,13 @@ importers:
         version: 1.32.0
       '@preconstruct/eslint-plugin-format-js-tag':
         specifier: ^0.3.0
-        version: 0.3.0(eslint@8.41.0)(prettier@2.8.8)(typescript@5.1.3)
+        version: 0.3.0(eslint@8.43.0)(prettier@2.8.8)(typescript@5.1.3)
       eslint:
-        specifier: ^8.41.0
-        version: 8.41.0
+        specifier: ^8.43.0
+        version: 8.43.0
       eslint-config-seek:
         specifier: ^11.1.2
-        version: 11.1.2(eslint@8.41.0)(typescript@5.1.3)
+        version: 11.1.2(eslint@8.43.0)(typescript@5.1.3)
       ignore-sync:
         specifier: ^7.0.1
         version: 7.0.1
@@ -617,7 +617,7 @@ packages:
     transitivePeerDependencies:
       - supports-color
 
-  /@babel/eslint-parser@7.19.1(@babel/core@7.21.4)(eslint@8.41.0):
+  /@babel/eslint-parser@7.19.1(@babel/core@7.21.4)(eslint@8.43.0):
     resolution: {integrity: sha512-AqNf2QWt1rtu2/1rLswy6CDP7H9Oh3mMhk177Y67Rg8d7RD9WfOLLv8CGn6tisFvS2htm86yIe1yLF6I1UDaGQ==}
     engines: {node: ^10.13.0 || ^12.13.0 || >=14.0.0}
     peerDependencies:
@@ -626,7 +626,7 @@ packages:
     dependencies:
       '@babel/core': 7.21.4
       '@nicolo-ribaudo/eslint-scope-5-internals': 5.1.1-v1
-      eslint: 8.41.0
+      eslint: 8.43.0
       eslint-visitor-keys: 2.1.0
       semver: 6.3.0
     dev: false
@@ -1745,13 +1745,13 @@ packages:
     requiresBuild: true
     optional: true
 
-  /@eslint-community/eslint-utils@4.4.0(eslint@8.41.0):
+  /@eslint-community/eslint-utils@4.4.0(eslint@8.43.0):
     resolution: {integrity: sha512-1/sA4dwrzBAyeUoQ6oxahHKmrZvsnLCg4RfxW3ZFGGmQkSNQPFNLV9CUEFQP1x9EYXHTo5p6xdhZM1Ne9p/AfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || >=8.0.0
     dependencies:
-      eslint: 8.41.0
+      eslint: 8.43.0
       eslint-visitor-keys: 3.4.1
     dev: false
 
@@ -1777,18 +1777,18 @@ packages:
       - supports-color
     dev: false
 
-  /@eslint/js@8.41.0:
-    resolution: {integrity: sha512-LxcyMGxwmTh2lY9FwHPGWOHmYFCZvbrFCBZL4FzSSsxsRPuhrYUg/49/0KDfW8tnIEaEHtfmn6+NPN+1DqaNmA==}
+  /@eslint/js@8.43.0:
+    resolution: {integrity: sha512-s2UHCoiXfxMvmfzqoN+vrQ84ahUSYde9qNO1MdxmoEhyHWsfmwOpFlwYV+ePJEVc7gFnATGUi376WowX1N7tFg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@finsit/eslint-plugin-cypress@3.1.1(eslint@8.41.0):
+  /@finsit/eslint-plugin-cypress@3.1.1(eslint@8.43.0):
     resolution: {integrity: sha512-cowFcoYNYOjg/yxKlQ7f26uiGl7FK2Sksvo0KaBnRF0EZbIJTv3apSRLB1RqaTg1N5bhLL9EpVwXqXRpcICNQg==}
     engines: {node: '>=8.10.0'}
     peerDependencies:
       eslint: '>= 7.0.0'
     dependencies:
-      eslint: 8.41.0
+      eslint: 8.43.0
       globals: 13.20.0
     dev: false
 
@@ -1821,8 +1821,8 @@ packages:
     dependencies:
       tslib: 2.4.0
 
-  /@humanwhocodes/config-array@0.11.8:
-    resolution: {integrity: sha512-UybHIJzJnR5Qc/MsD9Kr+RpO2h+/P1GhOwdiLPXK5TWk5sgTdu88bTD9UP+CKbPPh5Rni1u0GjAdYQLemG8g+g==}
+  /@humanwhocodes/config-array@0.11.10:
+    resolution: {integrity: sha512-KVVjQmNUepDVGXNuoRRdmmEjruj0KfiGSbS8LVc12LMsWDQzRXJ0qdhN8L8uUigKpfEHRhlaQFY0ib1tnUbNeQ==}
     engines: {node: '>=10.10.0'}
     dependencies:
       '@humanwhocodes/object-schema': 1.2.1
@@ -2015,12 +2015,12 @@ packages:
     resolution: {integrity: sha512-50/17A98tWUfQ176raKiOGXuYpLyyVMkxxG6oylzL3BPOlA6ADGdK7EYunSa4I064xerltq9TGXs8HmOk5E+vw==}
     dev: false
 
-  /@preconstruct/eslint-plugin-format-js-tag@0.3.0(eslint@8.41.0)(prettier@2.8.8)(typescript@5.1.3):
+  /@preconstruct/eslint-plugin-format-js-tag@0.3.0(eslint@8.43.0)(prettier@2.8.8)(typescript@5.1.3):
     resolution: {integrity: sha512-PWs1ddbxhrO3g04CkS7x0AS8lBI3ruVVSjTHAJlMToBFu4byAaAxkv8Jm0DnW4BzkK3sOTEpi2f0CcLmRIypVg==}
     peerDependencies:
       prettier: '*'
     dependencies:
-      '@typescript-eslint/experimental-utils': 5.36.2(eslint@8.41.0)(typescript@5.1.3)
+      '@typescript-eslint/experimental-utils': 5.36.2(eslint@8.43.0)(typescript@5.1.3)
       prettier: 2.8.8
     transitivePeerDependencies:
       - eslint
@@ -2501,7 +2501,7 @@ packages:
     resolution: {integrity: sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==}
     dev: false
 
-  /@typescript-eslint/eslint-plugin@5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.41.0)(typescript@5.1.3):
+  /@typescript-eslint/eslint-plugin@5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.43.0)(typescript@5.1.3):
     resolution: {integrity: sha512-itag0qpN6q2UMM6Xgk6xoHa0D0/P+M17THnr4SVgqn9Rgam5k/He33MA7/D7QoJcdMxHFyX7U9imaBonAX/6qA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2513,12 +2513,12 @@ packages:
         optional: true
     dependencies:
       '@eslint-community/regexpp': 4.5.0
-      '@typescript-eslint/parser': 5.57.0(eslint@8.41.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 5.57.0(eslint@8.43.0)(typescript@5.1.3)
       '@typescript-eslint/scope-manager': 5.57.0
-      '@typescript-eslint/type-utils': 5.57.0(eslint@8.41.0)(typescript@5.1.3)
-      '@typescript-eslint/utils': 5.57.0(eslint@8.41.0)(typescript@5.1.3)
+      '@typescript-eslint/type-utils': 5.57.0(eslint@8.43.0)(typescript@5.1.3)
+      '@typescript-eslint/utils': 5.57.0(eslint@8.43.0)(typescript@5.1.3)
       debug: 4.3.4
-      eslint: 8.41.0
+      eslint: 8.43.0
       grapheme-splitter: 1.0.4
       ignore: 5.2.0
       natural-compare-lite: 1.4.0
@@ -2529,20 +2529,20 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/experimental-utils@5.36.2(eslint@8.41.0)(typescript@5.1.3):
+  /@typescript-eslint/experimental-utils@5.36.2(eslint@8.43.0)(typescript@5.1.3):
     resolution: {integrity: sha512-JtRmWb31KQoxGV6CHz8cI+9ki6cC7ciZepXYpCLxsdAtQlBrRBxh5Qpe/ZHyJFOT9j7gyXE+W0shWzRLPfuAFQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@typescript-eslint/utils': 5.36.2(eslint@8.41.0)(typescript@5.1.3)
-      eslint: 8.41.0
+      '@typescript-eslint/utils': 5.36.2(eslint@8.43.0)(typescript@5.1.3)
+      eslint: 8.43.0
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@typescript-eslint/parser@5.57.0(eslint@8.41.0)(typescript@5.1.3):
+  /@typescript-eslint/parser@5.57.0(eslint@8.43.0)(typescript@5.1.3):
     resolution: {integrity: sha512-orrduvpWYkgLCyAdNtR1QIWovcNZlEm6yL8nwH/eTxWLd8gsP+25pdLHYzL2QdkqrieaDwLpytHqycncv0woUQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2556,7 +2556,7 @@ packages:
       '@typescript-eslint/types': 5.57.0
       '@typescript-eslint/typescript-estree': 5.57.0(typescript@5.1.3)
       debug: 4.3.4
-      eslint: 8.41.0
+      eslint: 8.43.0
       typescript: 5.1.3
     transitivePeerDependencies:
       - supports-color
@@ -2578,7 +2578,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.57.0
     dev: false
 
-  /@typescript-eslint/type-utils@5.57.0(eslint@8.41.0)(typescript@5.1.3):
+  /@typescript-eslint/type-utils@5.57.0(eslint@8.43.0)(typescript@5.1.3):
     resolution: {integrity: sha512-kxXoq9zOTbvqzLbdNKy1yFrxLC6GDJFE2Yuo3KqSwTmDOFjUGeWSakgoXT864WcK5/NAJkkONCiKb1ddsqhLXQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2589,9 +2589,9 @@ packages:
         optional: true
     dependencies:
       '@typescript-eslint/typescript-estree': 5.57.0(typescript@5.1.3)
-      '@typescript-eslint/utils': 5.57.0(eslint@8.41.0)(typescript@5.1.3)
+      '@typescript-eslint/utils': 5.57.0(eslint@8.43.0)(typescript@5.1.3)
       debug: 4.3.4
-      eslint: 8.41.0
+      eslint: 8.43.0
       tsutils: 3.21.0(typescript@5.1.3)
       typescript: 5.1.3
     transitivePeerDependencies:
@@ -2650,7 +2650,7 @@ packages:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils@5.36.2(eslint@8.41.0)(typescript@5.1.3):
+  /@typescript-eslint/utils@5.36.2(eslint@8.43.0)(typescript@5.1.3):
     resolution: {integrity: sha512-uNcopWonEITX96v9pefk9DC1bWMdkweeSsewJ6GeC7L6j2t0SJywisgkr9wUTtXk90fi2Eljj90HSHm3OGdGRg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -2660,27 +2660,27 @@ packages:
       '@typescript-eslint/scope-manager': 5.36.2
       '@typescript-eslint/types': 5.36.2
       '@typescript-eslint/typescript-estree': 5.36.2(typescript@5.1.3)
-      eslint: 8.41.0
+      eslint: 8.43.0
       eslint-scope: 5.1.1
-      eslint-utils: 3.0.0(eslint@8.41.0)
+      eslint-utils: 3.0.0(eslint@8.43.0)
     transitivePeerDependencies:
       - supports-color
       - typescript
     dev: false
 
-  /@typescript-eslint/utils@5.57.0(eslint@8.41.0)(typescript@5.1.3):
+  /@typescript-eslint/utils@5.57.0(eslint@8.43.0)(typescript@5.1.3):
     resolution: {integrity: sha512-ps/4WohXV7C+LTSgAL5CApxvxbMkl9B9AUZRtnEFonpIxZDIT7wC1xfvuJONMidrkB9scs4zhtRyIwHh4+18kw==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
       eslint: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.41.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.43.0)
       '@types/json-schema': 7.0.11
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.57.0
       '@typescript-eslint/types': 5.57.0
       '@typescript-eslint/typescript-estree': 5.57.0(typescript@5.1.3)
-      eslint: 8.41.0
+      eslint: 8.43.0
       eslint-scope: 5.1.1
       semver: 7.5.1
     transitivePeerDependencies:
@@ -4468,35 +4468,35 @@ packages:
     engines: {node: '>=10'}
     dev: false
 
-  /eslint-config-prettier@8.6.0(eslint@8.41.0):
+  /eslint-config-prettier@8.6.0(eslint@8.43.0):
     resolution: {integrity: sha512-bAF0eLpLVqP5oEVUFKpMA+NnRFICwn9X8B5jrR9FcqnYBuPbqWEjTEspPWMj5ye6czoSLDweCzSo3Ko7gGrZaA==}
     hasBin: true
     peerDependencies:
       eslint: '>=7.0.0'
     dependencies:
-      eslint: 8.41.0
+      eslint: 8.43.0
     dev: false
 
-  /eslint-config-seek@11.1.2(eslint@8.41.0)(typescript@5.1.3):
+  /eslint-config-seek@11.1.2(eslint@8.43.0)(typescript@5.1.3):
     resolution: {integrity: sha512-L7EtzOdQAKWM9/eepWPjLV4CEHHwGBt6XjkkzXbLnxmc6f9MtiFVVA7YCpq6KuhSl3/cHKAVVLBrZmJvyYCHwA==}
     peerDependencies:
       eslint: '>=6'
       typescript: '>=4.5'
     dependencies:
       '@babel/core': 7.21.4
-      '@babel/eslint-parser': 7.19.1(@babel/core@7.21.4)(eslint@8.41.0)
+      '@babel/eslint-parser': 7.19.1(@babel/core@7.21.4)(eslint@8.43.0)
       '@babel/preset-react': 7.18.6(@babel/core@7.21.4)
-      '@finsit/eslint-plugin-cypress': 3.1.1(eslint@8.41.0)
-      '@typescript-eslint/eslint-plugin': 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.41.0)(typescript@5.1.3)
-      '@typescript-eslint/parser': 5.57.0(eslint@8.41.0)(typescript@5.1.3)
-      eslint: 8.41.0
-      eslint-config-prettier: 8.6.0(eslint@8.41.0)
-      eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.27.5)(eslint@8.41.0)
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.57.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.41.0)
-      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.57.0)(eslint@8.41.0)(typescript@5.1.3)
+      '@finsit/eslint-plugin-cypress': 3.1.1(eslint@8.43.0)
+      '@typescript-eslint/eslint-plugin': 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.43.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 5.57.0(eslint@8.43.0)(typescript@5.1.3)
+      eslint: 8.43.0
+      eslint-config-prettier: 8.6.0(eslint@8.43.0)
+      eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.27.5)(eslint@8.43.0)
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.57.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.43.0)
+      eslint-plugin-jest: 27.2.1(@typescript-eslint/eslint-plugin@5.57.0)(eslint@8.43.0)(typescript@5.1.3)
       eslint-plugin-local-rules: 1.3.2
-      eslint-plugin-react: 7.32.2(eslint@8.41.0)
-      eslint-plugin-react-hooks: 4.6.0(eslint@8.41.0)
+      eslint-plugin-react: 7.32.2(eslint@8.43.0)
+      eslint-plugin-react-hooks: 4.6.0(eslint@8.43.0)
       find-root: 1.1.0
       typescript: 5.1.3
     transitivePeerDependencies:
@@ -4515,7 +4515,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.27.5)(eslint@8.41.0):
+  /eslint-import-resolver-typescript@3.5.3(eslint-plugin-import@2.27.5)(eslint@8.43.0):
     resolution: {integrity: sha512-njRcKYBc3isE42LaTcJNVANR3R99H9bAxBDMNDr2W7yq5gYPxbU3MkdhsQukxZ/Xg9C2vcyLlDsbKfRDg0QvCQ==}
     engines: {node: ^14.18.0 || >=16.0.0}
     peerDependencies:
@@ -4524,8 +4524,8 @@ packages:
     dependencies:
       debug: 4.3.4
       enhanced-resolve: 5.12.0
-      eslint: 8.41.0
-      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.57.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.41.0)
+      eslint: 8.43.0
+      eslint-plugin-import: 2.27.5(@typescript-eslint/parser@5.57.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.43.0)
       get-tsconfig: 4.2.0
       globby: 13.1.3
       is-core-module: 2.11.0
@@ -4535,7 +4535,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.57.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.3)(eslint@8.41.0):
+  /eslint-module-utils@2.7.4(@typescript-eslint/parser@5.57.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.3)(eslint@8.43.0):
     resolution: {integrity: sha512-j4GT+rqzCoRKHwURX7pddtIPGySnX9Si/cgMI5ztrcqOPtk5dDEeZ34CQVPphnqkJytlc97Vuk05Um2mJ3gEQA==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4556,16 +4556,16 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.57.0(eslint@8.41.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 5.57.0(eslint@8.43.0)(typescript@5.1.3)
       debug: 3.2.7
-      eslint: 8.41.0
+      eslint: 8.43.0
       eslint-import-resolver-node: 0.3.7
-      eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.27.5)(eslint@8.41.0)
+      eslint-import-resolver-typescript: 3.5.3(eslint-plugin-import@2.27.5)(eslint@8.43.0)
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.57.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.41.0):
+  /eslint-plugin-import@2.27.5(@typescript-eslint/parser@5.57.0)(eslint-import-resolver-typescript@3.5.3)(eslint@8.43.0):
     resolution: {integrity: sha512-LmEt3GVofgiGuiE+ORpnvP+kAm3h6MLZJ4Q5HCyHADofsb4VzXFsRiWj3c0OFiV+3DWFh0qg3v9gcPlfc3zRow==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4575,15 +4575,15 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.57.0(eslint@8.41.0)(typescript@5.1.3)
+      '@typescript-eslint/parser': 5.57.0(eslint@8.43.0)(typescript@5.1.3)
       array-includes: 3.1.6
       array.prototype.flat: 1.3.1
       array.prototype.flatmap: 1.3.1
       debug: 3.2.7
       doctrine: 2.1.0
-      eslint: 8.41.0
+      eslint: 8.43.0
       eslint-import-resolver-node: 0.3.7
-      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.57.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.3)(eslint@8.41.0)
+      eslint-module-utils: 2.7.4(@typescript-eslint/parser@5.57.0)(eslint-import-resolver-node@0.3.7)(eslint-import-resolver-typescript@3.5.3)(eslint@8.43.0)
       has: 1.0.3
       is-core-module: 2.11.0
       is-glob: 4.0.3
@@ -4598,7 +4598,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.57.0)(eslint@8.41.0)(typescript@5.1.3):
+  /eslint-plugin-jest@27.2.1(@typescript-eslint/eslint-plugin@5.57.0)(eslint@8.43.0)(typescript@5.1.3):
     resolution: {integrity: sha512-l067Uxx7ZT8cO9NJuf+eJHvt6bqJyz2Z29wykyEdz/OtmcELQl2MQGQLX8J94O1cSJWAwUSEvCjwjA7KEK3Hmg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -4611,9 +4611,9 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.41.0)(typescript@5.1.3)
-      '@typescript-eslint/utils': 5.57.0(eslint@8.41.0)(typescript@5.1.3)
-      eslint: 8.41.0
+      '@typescript-eslint/eslint-plugin': 5.57.0(@typescript-eslint/parser@5.57.0)(eslint@8.43.0)(typescript@5.1.3)
+      '@typescript-eslint/utils': 5.57.0(eslint@8.43.0)(typescript@5.1.3)
+      eslint: 8.43.0
     transitivePeerDependencies:
       - supports-color
       - typescript
@@ -4623,16 +4623,16 @@ packages:
     resolution: {integrity: sha512-X4ziX+cjlCYnZa+GB1ly3mmj44v2PeIld3tQVAxelY6AMrhHSjz6zsgsT6nt0+X5b7eZnvL/O7Q3pSSK2kF/+Q==}
     dev: false
 
-  /eslint-plugin-react-hooks@4.6.0(eslint@8.41.0):
+  /eslint-plugin-react-hooks@4.6.0(eslint@8.43.0):
     resolution: {integrity: sha512-oFc7Itz9Qxh2x4gNHStv3BqJq54ExXmfC+a1NjAta66IAN87Wu0R/QArgIS9qKzX3dXKPI9H5crl9QchNMY9+g==}
     engines: {node: '>=10'}
     peerDependencies:
       eslint: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0
     dependencies:
-      eslint: 8.41.0
+      eslint: 8.43.0
     dev: false
 
-  /eslint-plugin-react@7.32.2(eslint@8.41.0):
+  /eslint-plugin-react@7.32.2(eslint@8.43.0):
     resolution: {integrity: sha512-t2fBMa+XzonrrNkyVirzKlvn5RXzzPwRHtMvLAtVZrt8oxgnTQaYbU6SXTOO1mwQgp1y5+toMSKInnzGr0Knqg==}
     engines: {node: '>=4'}
     peerDependencies:
@@ -4642,7 +4642,7 @@ packages:
       array.prototype.flatmap: 1.3.1
       array.prototype.tosorted: 1.1.1
       doctrine: 2.1.0
-      eslint: 8.41.0
+      eslint: 8.43.0
       estraverse: 5.3.0
       jsx-ast-utils: 3.3.3
       minimatch: 3.1.2
@@ -4671,13 +4671,13 @@ packages:
       estraverse: 5.3.0
     dev: false
 
-  /eslint-utils@3.0.0(eslint@8.41.0):
+  /eslint-utils@3.0.0(eslint@8.43.0):
     resolution: {integrity: sha512-uuQC43IGctw68pJA1RgbQS8/NP7rch6Cwd4j3ZBtgo4/8Flj4eGE7ZYSZRN3iq5pVUv6GPdW5Z1RFleo84uLDA==}
     engines: {node: ^10.0.0 || ^12.0.0 || >= 14.0.0}
     peerDependencies:
       eslint: '>=5'
     dependencies:
-      eslint: 8.41.0
+      eslint: 8.43.0
       eslint-visitor-keys: 2.1.0
     dev: false
 
@@ -4691,16 +4691,16 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /eslint@8.41.0:
-    resolution: {integrity: sha512-WQDQpzGBOP5IrXPo4Hc0814r4/v2rrIsB0rhT7jtunIalgg6gYXWhRMOejVO8yH21T/FGaxjmFjBMNqcIlmH1Q==}
+  /eslint@8.43.0:
+    resolution: {integrity: sha512-aaCpf2JqqKesMFGgmRPessmVKjcGXqdlAYLLC3THM8t5nBRZRQ+st5WM/hoJXkdioEXLLbXgclUpM0TXo5HX5Q==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     hasBin: true
     dependencies:
-      '@eslint-community/eslint-utils': 4.4.0(eslint@8.41.0)
+      '@eslint-community/eslint-utils': 4.4.0(eslint@8.43.0)
       '@eslint-community/regexpp': 4.5.0
       '@eslint/eslintrc': 2.0.3
-      '@eslint/js': 8.41.0
-      '@humanwhocodes/config-array': 0.11.8
+      '@eslint/js': 8.43.0
+      '@humanwhocodes/config-array': 0.11.10
       '@humanwhocodes/module-importer': 1.0.1
       '@nodelib/fs.walk': 1.2.8
       ajv: 6.12.6


### PR DESCRIPTION

Re-export `CrackleConfig` and `defineConfig` from `@crackle/cli/config` so that they can be used in `crackle.config.ts` without adding `@crackle/core` as a dependency

```ts
// crackle.config.ts
import { defineConfig } from '@crackle/cli/config';

export default defineConfig({
  // ...
});
```