### PR TITLE
Allow Snapshot workflow to be triggered manually

### DIFF
--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -7,6 +7,8 @@ on:
       - master
     tags-ignore:
       - '**'
+  # we don't want the pending indicator, but we might want to trigger it manually on the Version Packages PR
+  workflow_dispatch:
 
 env:
   CI: true


### PR DESCRIPTION
We don't want the pending indicator, but we might want to trigger it manually on the Version Packages PR