### PR TITLE
Fix `braid-site` fixture build

### DIFF
--- a/packages/core/src/entries/route-data.ts
+++ b/packages/core/src/entries/route-data.ts
@@ -1,6 +1,11 @@
 import path from 'path';
 
 import { transformFileAsync as babelTransform } from '@babel/core';
+// @ts-expect-error no types
+import babelPluginSyntaxJsx from '@babel/plugin-syntax-jsx';
+// @ts-expect-error no types
+import babelPluginSyntaxTypescript from '@babel/plugin-syntax-typescript';
+import babelPluginRemoveExports from '@crackle/babel-plugin-remove-exports';
 import type { RouteData } from '@crackle/router';
 import { build as esbuild } from 'esbuild';
 import _eval from 'eval';
@@ -17,12 +22,9 @@ const transformWithBabel = async (file: string) => {
   // TODO: merge with src/plugins/vite/strip-route-data.ts
   const transformedContents = await babelTransform(file, {
     plugins: [
-      [
-        require.resolve('@crackle/babel-plugin-remove-exports'),
-        { retainExports: ['routeData'] },
-      ],
-      require.resolve('@babel/plugin-syntax-jsx'),
-      [require.resolve('@babel/plugin-syntax-typescript'), { isTSX: true }],
+      [babelPluginRemoveExports, { retainExports: ['routeData'] }],
+      babelPluginSyntaxJsx,
+      [babelPluginSyntaxTypescript, { isTSX: true }],
     ],
     babelrc: false,
     configFile: false,

--- a/packages/core/src/plugins/vite/strip-route-data.ts
+++ b/packages/core/src/plugins/vite/strip-route-data.ts
@@ -1,4 +1,9 @@
 import { transformAsync as babelTransform } from '@babel/core';
+// @ts-expect-error no types
+import babelPluginSyntaxJsx from '@babel/plugin-syntax-jsx';
+// @ts-expect-error no types
+import babelPluginSyntaxTypescript from '@babel/plugin-syntax-typescript';
+import babelPluginRemoveExports from '@crackle/babel-plugin-remove-exports';
 import type { Plugin } from 'vite';
 
 export const stripRouteData = (): Plugin => ({
@@ -13,11 +18,11 @@ export const stripRouteData = (): Plugin => ({
     const transformedContents = await babelTransform(code, {
       plugins: [
         [
-          require.resolve('@crackle/babel-plugin-remove-exports'),
+          babelPluginRemoveExports,
           { retainDefault: true, retainIdentifiers: ['React'] },
         ],
-        require.resolve('@babel/plugin-syntax-jsx'),
-        [require.resolve('@babel/plugin-syntax-typescript'), { isTSX: true }],
+        babelPluginSyntaxJsx,
+        [babelPluginSyntaxTypescript, { isTSX: true }],
       ],
       babelrc: false,
       configFile: false,


### PR DESCRIPTION
The build was broken for the `braid-site` fixture due to usage of `require` in a `.mjs` file. This was coming from the `require.resolve`s used for babel plugin resolution, so I replaced them with regular imports. I don't _think_ these need to be `require.resolve`s, but feel free to prove me wrong.

**NOTE**: The build is still broken for `braid-site` after running `pnpm dev`, but for a separate reason.