### PR TITLE
Use the correct flag to skip duplicate actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,8 @@ jobs:
         id: skip_check
         with:
           concurrent_skipping: same_content_newer
-          cancel_others: true
+          # We want to skip only concurrent runs. Subsequent runs/retries should be allowed.
+          skip_after_successful_duplicate: false
 
   build:
     name: Build


### PR DESCRIPTION
With the fix from https://github.com/seek-oss/braid-design-system/pull/1310