### PR TITLE
Renovate: Ignore internal packages (correctly)

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -9,12 +9,12 @@
   "ignorePaths": ["bootstrap/**"],
   "packageRules": [
     {
-      "matchPackageNames": ["@crackle-fixtures/*"],
+      "matchPackagePatterns": ["^@crackle-fixtures/"],
       "enabled": false,
     },
     {
       "groupName": "typescript",
-      "packagePatterns": ["^typescript$"],
+      "matchPackagePatterns": ["^typescript$"],
       "enabled": true,
       "schedule": ["before 8am on Tuesday"],
     },


### PR DESCRIPTION
Some config options were incorrect.