### PR TITLE
Update Braid integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,7 +126,7 @@ jobs:
           echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
 
       - name: Clone Braid repo
-        run: pnpm fixtures:braid --branch master --clone --absorb
+        run: pnpm fixtures:braid --clone --absorb
 
       - name: Cache Braid dependencies
         uses: actions/cache@v3

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fixtures/braid-design-system"]
 	path = fixtures/braid-design-system
 	url = git@github.com:seek-oss/braid-design-system.git
-	branch = integration
+	branch = master

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "fixtures/braid-design-system"]
 	path = fixtures/braid-design-system
 	url = git@github.com:seek-oss/braid-design-system.git
-	branch = master
+	branch = integration

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,7 @@ packages:
   - 'packages/*'
   - 'fixtures/*'
   - fixtures/braid-design-system # Braid monorepo deps (required for integration tests)
-  - fixtures/braid-design-system/fixtures/* # Braid's integration tests
+  - fixtures/braid-design-system/integration # Braid's integration tests
   - fixtures/braid-design-system/packages/braid-design-system
   - bootstrap
   - scripts

--- a/scripts/braid-fixture.ts
+++ b/scripts/braid-fixture.ts
@@ -46,17 +46,16 @@ const clean = async (location: string) =>
 
 // Get the current branch name
 if (branch === '__current__') {
-  const buffer = await run(`git submodule status ${submodule}`, {
-    encoding: 'utf-8',
-    stdio: 'pipe',
-  });
-  const current = new RegExp(`.*${submodule}.*\\(heads/(?<current>.*)\\)`).exec(
-    buffer.toString(),
-  )?.groups?.current;
+  const result = await run(
+    `git config --file .gitmodules --get submodule.${submodule}.branch`,
+    {
+      encoding: 'utf-8',
+      stdio: 'pipe',
+    },
+  );
+  branch = result.toString().trim();
 
-  assert(current, 'Could not get current branch name');
-
-  branch = current;
+  assert(branch, 'Could not get current branch name');
 }
 
 // Modified from https://stackoverflow.com/questions/45688121/how-to-do-submodule-sparse-checkout-with-git/45689692//45689692

--- a/scripts/braid-fixture.ts
+++ b/scripts/braid-fixture.ts
@@ -77,8 +77,8 @@ if (argv.absorb) {
   await fse.appendFile(
     fromRoot(`.git/modules/${submodule}/info/sparse-checkout`),
     dedent`
-      /fixtures/*
       /packages/braid-design-system/*
+      /integration/
       /jest*
       /package.json
       /pnpm-lock.yaml
@@ -108,7 +108,7 @@ if (argv.test) {
 
   if (argv.test === 'integration') {
     // Run Braid's integration tests
-    await run(`pnpm test:fixtures`, { cwd: fromRoot(submodule) });
+    await run(`pnpm test:integration`, { cwd: fromRoot(submodule) });
   }
 }
 

--- a/scripts/braid-fixture.ts
+++ b/scripts/braid-fixture.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import path from 'path';
 import { fileURLToPath } from 'url';
 
@@ -9,7 +10,7 @@ import { run as _run, done } from './utils';
 
 const argv = await yargs(process.argv.slice(2))
   .option('branch', {
-    default: 'master',
+    default: '__current__',
     requiresArg: true,
   })
   .option('clone', {
@@ -35,13 +36,28 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 const repo = 'git@github.com:seek-oss/braid-design-system.git';
 const submodule = 'fixtures/braid-design-system';
-const branch = argv.branch;
+let branch = argv.branch;
 
 const fromRoot = (location: string) => path.resolve(__dirname, '..', location);
 const run: typeof _run = (command, options) =>
   _run(command, { cwd: fromRoot('.'), ...options });
 const clean = async (location: string) =>
   (await fse.exists(fromRoot(location))) && run(`rm -fr ${location}`);
+
+// Get the current branch name
+if (branch === '__current__') {
+  const buffer = await run(`git submodule status ${submodule}`, {
+    encoding: 'utf-8',
+    stdio: 'pipe',
+  });
+  const current = new RegExp(`.*${submodule}.*\\(heads/(?<current>.*)\\)`).exec(
+    buffer.toString(),
+  )?.groups?.current;
+
+  assert(current, 'Could not get current branch name');
+
+  branch = current;
+}
 
 // Modified from https://stackoverflow.com/questions/45688121/how-to-do-submodule-sparse-checkout-with-git/45689692//45689692
 

--- a/scripts/utils.ts
+++ b/scripts/utils.ts
@@ -2,13 +2,18 @@ import { execSync } from 'child_process';
 
 export const run = async (
   command: string,
-  { cwd }: Parameters<typeof execSync>[1] = {},
+  { cwd, ...options }: Parameters<typeof execSync>[1] = {},
 ) => {
   const cwdSuffix = cwd ? ` (in ${cwd})` : '';
   console.log(`🛠  ${command}${cwdSuffix}...`);
-  execSync(command, { cwd, stdio: 'inherit' });
+  const output = execSync(command, {
+    cwd,
+    stdio: 'inherit',
+    ...options,
+  });
   console.log(`✅ ${command}`);
   console.log();
+  return output;
 };
 
 export const done = () => console.log('✨ Done.');


### PR DESCRIPTION
Depends on https://github.com/seek-oss/braid-design-system/pull/1410

Integration tests in #153 fail because Braid's task graph has changed. I've published a branch in Braid that allows us to still run Braid's integration tests.