### PR TITLE
Generate correct types according to https://arethetypeswrong.github.io

### DIFF
--- a/.changeset/bright-coins-cover.md
+++ b/.changeset/bright-coins-cover.md
@@ -1,0 +1,8 @@
+---
+'@crackle/babel-plugin-remove-exports': minor
+'@crackle/router': minor
+'@crackle/core': minor
+'@crackle/cli': minor
+---
+
+Now generating types correctly according do https://arethetypeswrong.github.io

--- a/fixtures/dev-entries-webpack/package.json
+++ b/fixtures/dev-entries-webpack/package.json
@@ -6,12 +6,18 @@
   "author": "SEEK",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./cli": {
-      "types": "./dist/cli.d.ts",
+      "types": {
+        "import": "./dist/cli.d.mts",
+        "require": "./dist/cli.d.ts"
+      },
       "import": "./dist/cli.mjs",
       "require": "./dist/cli.cjs"
     },

--- a/fixtures/dev-entries/package.json
+++ b/fixtures/dev-entries/package.json
@@ -6,17 +6,26 @@
   "author": "SEEK",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./cli": {
-      "types": "./dist/cli.d.ts",
+      "types": {
+        "import": "./dist/cli.d.mts",
+        "require": "./dist/cli.d.ts"
+      },
       "import": "./dist/cli.mjs",
       "require": "./dist/cli.cjs"
     },
     "./re-export": {
-      "types": "./dist/re-export.d.ts",
+      "types": {
+        "import": "./dist/re-export.d.mts",
+        "require": "./dist/re-export.d.ts"
+      },
       "import": "./dist/re-export.mjs",
       "require": "./dist/re-export.cjs"
     },

--- a/fixtures/dts-compat/package.json
+++ b/fixtures/dts-compat/package.json
@@ -6,7 +6,10 @@
   "author": "SEEK",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },

--- a/fixtures/esm-compat/package.json
+++ b/fixtures/esm-compat/package.json
@@ -6,7 +6,10 @@
   "author": "SEEK",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },

--- a/fixtures/library-with-docs/package.json
+++ b/fixtures/library-with-docs/package.json
@@ -6,7 +6,10 @@
   "author": "SEEK",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },

--- a/fixtures/multi-entry-library/package.json
+++ b/fixtures/multi-entry-library/package.json
@@ -6,22 +6,34 @@
   "author": "SEEK",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./components": {
-      "types": "./dist/components.d.ts",
+      "types": {
+        "import": "./dist/components.d.mts",
+        "require": "./dist/components.d.ts"
+      },
       "import": "./dist/components.mjs",
       "require": "./dist/components.cjs"
     },
     "./extras": {
-      "types": "./dist/extras.d.ts",
+      "types": {
+        "import": "./dist/extras.d.mts",
+        "require": "./dist/extras.d.ts"
+      },
       "import": "./dist/extras.mjs",
       "require": "./dist/extras.cjs"
     },
     "./themes/apac": {
-      "types": "./dist/themes/apac.d.ts",
+      "types": {
+        "import": "./dist/themes/apac.d.mts",
+        "require": "./dist/themes/apac.d.ts"
+      },
       "import": "./dist/themes/apac.mjs",
       "require": "./dist/themes/apac.cjs"
     },

--- a/fixtures/single-entry-library/package.json
+++ b/fixtures/single-entry-library/package.json
@@ -6,7 +6,10 @@
   "author": "SEEK",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },

--- a/fixtures/with-dep-hidden-package-json/package.json
+++ b/fixtures/with-dep-hidden-package-json/package.json
@@ -6,7 +6,10 @@
   "author": "SEEK",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },

--- a/fixtures/with-graphql-schema-types/package.json
+++ b/fixtures/with-graphql-schema-types/package.json
@@ -6,7 +6,10 @@
   "author": "SEEK",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },

--- a/fixtures/with-side-effects/package.json
+++ b/fixtures/with-side-effects/package.json
@@ -14,22 +14,34 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./css": {
-      "types": "./dist/css.d.ts",
+      "types": {
+        "import": "./dist/css.d.mts",
+        "require": "./dist/css.d.ts"
+      },
       "import": "./dist/css.mjs",
       "require": "./dist/css.cjs"
     },
     "./css-more": {
-      "types": "./dist/css-more.d.ts",
+      "types": {
+        "import": "./dist/css-more.d.mts",
+        "require": "./dist/css-more.d.ts"
+      },
       "import": "./dist/css-more.mjs",
       "require": "./dist/css-more.cjs"
     },
     "./reset": {
-      "types": "./dist/reset.d.ts",
+      "types": {
+        "import": "./dist/reset.d.mts",
+        "require": "./dist/reset.d.ts"
+      },
       "import": "./dist/reset.mjs",
       "require": "./dist/reset.cjs"
     },

--- a/fixtures/with-styles/package.json
+++ b/fixtures/with-styles/package.json
@@ -6,7 +6,10 @@
   "author": "SEEK",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },

--- a/fixtures/with-vocab/package.json
+++ b/fixtures/with-vocab/package.json
@@ -10,7 +10,10 @@
   ],
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
   },
   "wireit": {
     "build:ci": {
-      "command": "pnpm build",
+      "command": "pnpm build --fix",
       "dependencies": [
         "bootstrap"
       ]

--- a/packages/babel-plugin-remove-exports/package.json
+++ b/packages/babel-plugin-remove-exports/package.json
@@ -6,7 +6,10 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -5,12 +5,18 @@
   "author": "SEEK",
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./config": {
-      "types": "./dist/config.d.ts",
+      "types": {
+        "import": "./dist/config.d.mts",
+        "require": "./dist/config.d.ts"
+      },
       "import": "./dist/config.mjs",
       "require": "./dist/config.cjs"
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -6,57 +6,90 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./build": {
-      "types": "./dist/build.d.ts",
+      "types": {
+        "import": "./dist/build.d.mts",
+        "require": "./dist/build.d.ts"
+      },
       "import": "./dist/build.mjs",
       "require": "./dist/build.cjs"
     },
     "./clean": {
-      "types": "./dist/clean.d.ts",
+      "types": {
+        "import": "./dist/clean.d.mts",
+        "require": "./dist/clean.d.ts"
+      },
       "import": "./dist/clean.mjs",
       "require": "./dist/clean.cjs"
     },
     "./dev": {
-      "types": "./dist/dev.d.ts",
+      "types": {
+        "import": "./dist/dev.d.mts",
+        "require": "./dist/dev.d.ts"
+      },
       "import": "./dist/dev.mjs",
       "require": "./dist/dev.cjs"
     },
     "./fix": {
-      "types": "./dist/fix.d.ts",
+      "types": {
+        "import": "./dist/fix.d.mts",
+        "require": "./dist/fix.d.ts"
+      },
       "import": "./dist/fix.mjs",
       "require": "./dist/fix.cjs"
     },
     "./logger": {
-      "types": "./dist/logger.d.ts",
+      "types": {
+        "import": "./dist/logger.d.mts",
+        "require": "./dist/logger.d.ts"
+      },
       "import": "./dist/logger.mjs",
       "require": "./dist/logger.cjs"
     },
     "./package": {
-      "types": "./dist/package.d.ts",
+      "types": {
+        "import": "./dist/package.d.mts",
+        "require": "./dist/package.d.ts"
+      },
       "import": "./dist/package.mjs",
       "require": "./dist/package.cjs"
     },
     "./resolve-config": {
-      "types": "./dist/resolve-config.d.ts",
+      "types": {
+        "import": "./dist/resolve-config.d.mts",
+        "require": "./dist/resolve-config.d.ts"
+      },
       "import": "./dist/resolve-config.mjs",
       "require": "./dist/resolve-config.cjs"
     },
     "./route-data": {
-      "types": "./dist/route-data.d.ts",
+      "types": {
+        "import": "./dist/route-data.d.mts",
+        "require": "./dist/route-data.d.ts"
+      },
       "import": "./dist/route-data.mjs",
       "require": "./dist/route-data.cjs"
     },
     "./serve": {
-      "types": "./dist/serve.d.ts",
+      "types": {
+        "import": "./dist/serve.d.mts",
+        "require": "./dist/serve.d.ts"
+      },
       "import": "./dist/serve.mjs",
       "require": "./dist/serve.cjs"
     },
     "./start": {
-      "types": "./dist/start.d.ts",
+      "types": {
+        "import": "./dist/start.d.mts",
+        "require": "./dist/start.d.ts"
+      },
       "import": "./dist/start.mjs",
       "require": "./dist/start.cjs"
     },

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -143,8 +143,7 @@
     "memfs": "^3.6.0",
     "sync-dependencies": "^1.0.4",
     "typescript": "*",
-    "unbuild": "^1.2.1",
-    "webpack": "^5.89.0"
+    "unbuild": "^1.2.1"
   },
   "peerDependencies": {
     "typescript": ">=5.2.2"

--- a/packages/core/src/package-utils/dts.ts
+++ b/packages/core/src/package-utils/dts.ts
@@ -1,3 +1,5 @@
+import path from 'path';
+
 import { rollup } from 'rollup';
 import dts from 'rollup-plugin-dts';
 
@@ -5,7 +7,8 @@ import type { EnhancedConfig } from '../config';
 import { logger } from '../entries/logger';
 import { externals } from '../plugins/rollup/externals';
 import type { PackageEntryPoint } from '../types';
-import { extensionForFormat } from '../utils/files';
+import { copyFile, extensionForFormat } from '../utils/files';
+import { promiseMap } from '../utils/promise-map';
 import { commonOutputOptions } from '../vite-config';
 
 export const createDtsBundle = async (
@@ -58,6 +61,13 @@ export const createDtsBundle = async (
   });
 
   await bundle.close();
+
+  await promiseMap(entries, async (entry) => {
+    await copyFile(
+      path.join(entry.outputDir, entry.getOutputPath('dts')),
+      path.join(entry.outputDir, entry.getOutputPath('dtsm')),
+    );
+  });
 
   return result;
 };

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -2,7 +2,7 @@ import type React from 'react';
 
 export type { PackageJson } from 'type-fest';
 
-export type Format = 'esm' | 'cjs' | 'dts';
+export type Format = 'cjs' | 'esm' | 'dts' | 'dtsm';
 
 type RoutePath = string;
 export type AppShell<MetadataType extends Record<string, any> | void = void> =

--- a/packages/core/src/utils/__snapshots__/setup-package-json.test.ts.snap
+++ b/packages/core/src/utils/__snapshots__/setup-package-json.test.ts.snap
@@ -35,17 +35,26 @@ exports[`diffPackageJson > empty package.json > package.json 1`] = `
 {
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts",
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs",
     },
     "./css": {
-      "types": "./dist/css.d.ts",
+      "types": {
+        "import": "./dist/css.d.mts",
+        "require": "./dist/css.d.ts",
+      },
       "import": "./dist/css.mjs",
       "require": "./dist/css.cjs",
     },
     "./themes/apac": {
-      "types": "./dist/themes/apac.d.ts",
+      "types": {
+        "import": "./dist/themes/apac.d.mts",
+        "require": "./dist/themes/apac.d.ts",
+      },
       "import": "./dist/themes/apac.mjs",
       "require": "./dist/themes/apac.cjs",
     },
@@ -79,17 +88,26 @@ Snapshot Diff:
   {
 +   "exports": {
 +     ".": {
-+       "types": "./dist/index.d.ts",
++       "types": {
++         "import": "./dist/index.d.mts",
++         "require": "./dist/index.d.ts",
++       },
 +       "import": "./dist/index.mjs",
 +       "require": "./dist/index.cjs",
 +     },
 +     "./css": {
-+       "types": "./dist/css.d.ts",
++       "types": {
++         "import": "./dist/css.d.mts",
++         "require": "./dist/css.d.ts",
++       },
 +       "import": "./dist/css.mjs",
 +       "require": "./dist/css.cjs",
 +     },
 +     "./themes/apac": {
-+       "types": "./dist/themes/apac.d.ts",
++       "types": {
++         "import": "./dist/themes/apac.d.mts",
++         "require": "./dist/themes/apac.d.ts",
++       },
 +       "import": "./dist/themes/apac.mjs",
 +       "require": "./dist/themes/apac.cjs",
 +     },
@@ -214,17 +232,26 @@ exports[`diffPackageJson > incorrect package.json > kitchen sink > package.json 
 {
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts",
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs",
     },
     "./css": {
-      "types": "./dist/css.d.ts",
+      "types": {
+        "import": "./dist/css.d.mts",
+        "require": "./dist/css.d.ts",
+      },
       "import": "./dist/css.mjs",
       "require": "./dist/css.cjs",
     },
     "./themes/apac": {
-      "types": "./dist/themes/apac.d.ts",
+      "types": {
+        "import": "./dist/themes/apac.d.mts",
+        "require": "./dist/themes/apac.d.ts",
+      },
       "import": "./dist/themes/apac.mjs",
       "require": "./dist/themes/apac.cjs",
     },

--- a/packages/core/src/utils/dev-entry-points.ts
+++ b/packages/core/src/utils/dev-entry-points.ts
@@ -144,6 +144,7 @@ export const generateDevFiles = async () => {
       await writeFile(entry, 'cjs', getCjsContents);
       await writeFile(entry, 'esm', getEsmContents);
       await writeFile(entry, 'dts', getDtsContents);
+      await writeFile(entry, 'dtsm', getDtsContents);
 
       logger.info(`✅ Created stubs for ${entry.entryName}`);
     });

--- a/packages/core/src/utils/entry-points.test.ts
+++ b/packages/core/src/utils/entry-points.test.ts
@@ -8,6 +8,7 @@ import {
   createEntryPackageJsons,
   getPackageEntryPoints,
 } from './entry-points';
+import { formats } from './files';
 
 const root = '/___';
 const volume = {
@@ -37,6 +38,9 @@ vi.mock('mlly', () => ({
     }
   },
 }));
+
+const byFormat = (cb: (format: (typeof formats)[number]) => string) =>
+  Object.fromEntries(formats.map((format) => [format, cb(format)]));
 
 describe('getPackageEntryPoints', () => {
   beforeEach(() => {
@@ -93,54 +97,60 @@ describe('getPackageEntryPoints', () => {
     const entryPoints = await getPackageEntryPoints(root);
     const entry = entryPoints.find(({ isDefaultEntry }) => isDefaultEntry)!;
 
-    expect(entry.getOutputPath('esm')).toMatchInlineSnapshot('"index.mjs"');
-    expect(entry.getOutputPath('cjs')).toMatchInlineSnapshot('"index.cjs"');
-    expect(entry.getOutputPath('dts')).toMatchInlineSnapshot('"index.d.ts"');
+    expect(byFormat((format) => entry.getOutputPath(format)))
+      .toMatchInlineSnapshot(`
+      {
+        "cjs": "index.cjs",
+        "dts": "index.d.ts",
+        "dtsm": "index.d.mts",
+        "esm": "index.mjs",
+      }
+    `);
   });
 
   test('getOutputPath (from root) for index', async () => {
     const entryPoints = await getPackageEntryPoints(root);
     const entry = entryPoints.find(({ isDefaultEntry }) => isDefaultEntry)!;
 
-    expect(entry.getOutputPath('esm', { from: root })).toMatchInlineSnapshot(
-      '"dist/index.mjs"',
-    );
-    expect(entry.getOutputPath('cjs', { from: root })).toMatchInlineSnapshot(
-      '"dist/index.cjs"',
-    );
-    expect(entry.getOutputPath('dts', { from: root })).toMatchInlineSnapshot(
-      '"dist/index.d.ts"',
-    );
+    expect(byFormat((format) => entry.getOutputPath(format, { from: root })))
+      .toMatchInlineSnapshot(`
+      {
+        "cjs": "dist/index.cjs",
+        "dts": "dist/index.d.ts",
+        "dtsm": "dist/index.d.mts",
+        "esm": "dist/index.mjs",
+      }
+    `);
   });
 
   test('getOutputPath for entry', async () => {
     const entryPoints = await getPackageEntryPoints(root);
     const entry = entryPoints.find(({ isDefaultEntry }) => !isDefaultEntry)!;
 
-    expect(entry.getOutputPath('esm')).toMatchInlineSnapshot(
-      '"components.mjs"',
-    );
-    expect(entry.getOutputPath('cjs')).toMatchInlineSnapshot(
-      '"components.cjs"',
-    );
-    expect(entry.getOutputPath('dts')).toMatchInlineSnapshot(
-      '"components.d.ts"',
-    );
+    expect(byFormat((format) => entry.getOutputPath(format)))
+      .toMatchInlineSnapshot(`
+      {
+        "cjs": "components.cjs",
+        "dts": "components.d.ts",
+        "dtsm": "components.d.mts",
+        "esm": "components.mjs",
+      }
+    `);
   });
 
   test('getOutputPath (from root) for entry', async () => {
     const entryPoints = await getPackageEntryPoints(root);
     const entry = entryPoints.find(({ isDefaultEntry }) => !isDefaultEntry)!;
 
-    expect(entry.getOutputPath('esm', { from: root })).toMatchInlineSnapshot(
-      '"dist/components.mjs"',
-    );
-    expect(entry.getOutputPath('cjs', { from: root })).toMatchInlineSnapshot(
-      '"dist/components.cjs"',
-    );
-    expect(entry.getOutputPath('dts', { from: root })).toMatchInlineSnapshot(
-      '"dist/components.d.ts"',
-    );
+    expect(byFormat((format) => entry.getOutputPath(format, { from: root })))
+      .toMatchInlineSnapshot(`
+      {
+        "cjs": "dist/components.cjs",
+        "dts": "dist/components.d.ts",
+        "dtsm": "dist/components.d.mts",
+        "esm": "dist/components.mjs",
+      }
+    `);
   });
 
   test('createEntryPackageJsons', async () => {

--- a/packages/core/src/utils/files.ts
+++ b/packages/core/src/utils/files.ts
@@ -20,6 +20,8 @@ const exists = async (filePath: string) => {
   }
 };
 
+export const copyFile = (from: string, to: string) => fse.copy(from, to);
+
 export const writeFile = async ({ dir, fileName, contents }: WriteFileOpts) => {
   await fse.mkdir(dir, { recursive: true });
   return fse.writeFile(path.join(dir, fileName), contents, 'utf-8');
@@ -83,5 +85,7 @@ export const emptyDir = async (dir: string, skip = ['.git']): Promise<void> => {
   }
 };
 
+export const formats: Format[] = ['cjs', 'esm', 'dts', 'dtsm'];
+
 export const extensionForFormat = (format: Format) =>
-  (({ esm: 'mjs', cjs: 'cjs', dts: 'd.ts' } as const)[format]);
+  (({ cjs: 'cjs', esm: 'mjs', dts: 'd.ts', dtsm: 'd.mts' } as const)[format]);

--- a/packages/core/src/utils/setup-package-json.test.ts
+++ b/packages/core/src/utils/setup-package-json.test.ts
@@ -58,17 +58,26 @@ describe('diffPackageJson', () => {
   const correctPackageJson = {
     exports: {
       '.': {
-        types: './dist/index.d.ts',
+        types: {
+          import: './dist/index.d.mts',
+          require: './dist/index.d.ts',
+        },
         import: './dist/index.mjs',
         require: './dist/index.cjs',
       },
       './css': {
-        types: './dist/css.d.ts',
+        types: {
+          import: './dist/css.d.mts',
+          require: './dist/css.d.ts',
+        },
         import: './dist/css.mjs',
         require: './dist/css.cjs',
       },
       './themes/apac': {
-        types: './dist/themes/apac.d.ts',
+        types: {
+          import: './dist/themes/apac.d.mts',
+          require: './dist/themes/apac.d.ts',
+        },
         import: './dist/themes/apac.mjs',
         require: './dist/themes/apac.cjs',
       },

--- a/packages/core/src/utils/setup-package-json.ts
+++ b/packages/core/src/utils/setup-package-json.ts
@@ -24,7 +24,7 @@ export type Difference =
 
 type ExportString = `./${string}`;
 type ExportObject = {
-  types: ExportString;
+  types: ExportString | Omit<ExportObject, 'types'>;
   import: ExportString;
   require: ExportString;
 };
@@ -64,7 +64,10 @@ const getExportsForPackage = (entries: Entry[], options: { from: string }) => {
   const exports: Exports = {};
   for (const entry of sortedEntries) {
     exports[entry.isDefaultEntry ? '.' : makeRelative(entry.entryName)] = {
-      types: makeRelative(entry.getOutputPath('dts', options)),
+      types: {
+        import: makeRelative(entry.getOutputPath('dtsm', options)),
+        require: makeRelative(entry.getOutputPath('dts', options)),
+      },
       import: makeRelative(entry.getOutputPath('esm', options)),
       require: makeRelative(entry.getOutputPath('cjs', options)),
     };

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -6,17 +6,26 @@
   "sideEffects": false,
   "exports": {
     ".": {
-      "types": "./dist/index.d.ts",
+      "types": {
+        "import": "./dist/index.d.mts",
+        "require": "./dist/index.d.ts"
+      },
       "import": "./dist/index.mjs",
       "require": "./dist/index.cjs"
     },
     "./routes": {
-      "types": "./dist/routes.d.ts",
+      "types": {
+        "import": "./dist/routes.d.mts",
+        "require": "./dist/routes.d.ts"
+      },
       "import": "./dist/routes.mjs",
       "require": "./dist/routes.cjs"
     },
     "./server": {
-      "types": "./dist/server.d.ts",
+      "types": {
+        "import": "./dist/server.d.mts",
+        "require": "./dist/server.d.ts"
+      },
       "import": "./dist/server.mjs",
       "require": "./dist/server.cjs"
     },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -520,9 +520,6 @@ importers:
       unbuild:
         specifier: ^1.2.1
         version: 1.2.1
-      webpack:
-        specifier: ^5.89.0
-        version: 5.89.0(esbuild@0.19.8)
 
   packages/router:
     dependencies:
@@ -9293,31 +9290,6 @@ packages:
     engines: {node: '>=8'}
     dev: false
 
-  /terser-webpack-plugin@5.3.9(esbuild@0.19.8)(webpack@5.89.0):
-    resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
-    engines: {node: '>= 10.13.0'}
-    peerDependencies:
-      '@swc/core': '*'
-      esbuild: '*'
-      uglify-js: '*'
-      webpack: ^5.1.0
-    peerDependenciesMeta:
-      '@swc/core':
-        optional: true
-      esbuild:
-        optional: true
-      uglify-js:
-        optional: true
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.20
-      esbuild: 0.19.8
-      jest-worker: 27.5.1
-      schema-utils: 3.3.0
-      serialize-javascript: 6.0.1
-      terser: 5.24.0
-      webpack: 5.89.0(esbuild@0.19.8)
-    dev: true
-
   /terser-webpack-plugin@5.3.9(webpack@5.89.0):
     resolution: {integrity: sha512-ZuXsqE07EcggTWQjXUj+Aot/OMcD0bMKGgF63f7UxYcu5/AJF53aIpK1YoP5xR9l6s/Hy2b+t1AM0bLNPRuhwA==}
     engines: {node: '>= 10.13.0'}
@@ -10051,46 +10023,6 @@ packages:
   /webpack-sources@3.2.3:
     resolution: {integrity: sha512-/DyMEOrDgLKKIG0fmvtz+4dUX/3Ghozwgm6iPp8KRhvn+eQf9+Q7GWxVNMk3+uCPWfdXYC4ExGBckIXdFEfH1w==}
     engines: {node: '>=10.13.0'}
-
-  /webpack@5.89.0(esbuild@0.19.8):
-    resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}
-    engines: {node: '>=10.13.0'}
-    hasBin: true
-    peerDependencies:
-      webpack-cli: '*'
-    peerDependenciesMeta:
-      webpack-cli:
-        optional: true
-    dependencies:
-      '@types/eslint-scope': 3.7.7
-      '@types/estree': 1.0.5
-      '@webassemblyjs/ast': 1.11.6
-      '@webassemblyjs/wasm-edit': 1.11.6
-      '@webassemblyjs/wasm-parser': 1.11.6
-      acorn: 8.11.2
-      acorn-import-assertions: 1.9.0(acorn@8.11.2)
-      browserslist: 4.22.1
-      chrome-trace-event: 1.0.3
-      enhanced-resolve: 5.15.0
-      es-module-lexer: 1.4.1
-      eslint-scope: 5.1.1
-      events: 3.3.0
-      glob-to-regexp: 0.4.1
-      graceful-fs: 4.2.11
-      json-parse-even-better-errors: 2.3.1
-      loader-runner: 4.3.0
-      mime-types: 2.1.35
-      neo-async: 2.6.2
-      schema-utils: 3.3.0
-      tapable: 2.2.1
-      terser-webpack-plugin: 5.3.9(esbuild@0.19.8)(webpack@5.89.0)
-      watchpack: 2.4.0
-      webpack-sources: 3.2.3
-    transitivePeerDependencies:
-      - '@swc/core'
-      - esbuild
-      - uglify-js
-    dev: true
 
   /webpack@5.89.0(webpack-cli@5.1.4):
     resolution: {integrity: sha512-qyfIC10pOr70V+jkmud8tMfajraGCZMBWJtrmuBymQKCrLTRejBI8STDp1MCyZu/QTdZSeacCQYpYNQVOzX5kw==}

--- a/scripts/braid-fixture.ts
+++ b/scripts/braid-fixture.ts
@@ -119,7 +119,7 @@ if (argv.test) {
   await runInBraid(`pnpm generate:icons`);
   await runInBraid(`pnpm generate:snippets`);
   // Run Braid's build command to make sure it still works & to generate the bundles
-  await runInBraid(`pnpm build`);
+  await runInBraid(`pnpm build --fix`);
 
   if (argv.test === 'integration') {
     // Run Braid's integration tests

--- a/tests/__snapshots__/dev/dev-entries-webpack/dist/cli.ts.snap
+++ b/tests/__snapshots__/dev/dev-entries-webpack/dist/cli.ts.snap
@@ -3,6 +3,11 @@ module.exports = require("../src/entries/cli.ts");
 /* #endregion */
 
 
+/* #region dist/cli.d.mts */
+export * from "../src/entries/cli";
+/* #endregion */
+
+
 /* #region dist/cli.d.ts */
 export * from "../src/entries/cli";
 /* #endregion */

--- a/tests/__snapshots__/dev/dev-entries-webpack/dist/index.ts.snap
+++ b/tests/__snapshots__/dev/dev-entries-webpack/dist/index.ts.snap
@@ -3,6 +3,12 @@ module.exports = require("../src/index.ts");
 /* #endregion */
 
 
+/* #region dist/index.d.mts */
+export * from "../src/index";
+export { default } from "../src/index";
+/* #endregion */
+
+
 /* #region dist/index.d.ts */
 export * from "../src/index";
 export { default } from "../src/index";

--- a/tests/__snapshots__/dev/dev-entries/dist/cli.ts.snap
+++ b/tests/__snapshots__/dev/dev-entries/dist/cli.ts.snap
@@ -5,6 +5,11 @@ module.exports = require("../src/entries/cli.ts");
 /* #endregion */
 
 
+/* #region dist/cli.d.mts */
+export * from "../src/entries/cli";
+/* #endregion */
+
+
 /* #region dist/cli.d.ts */
 export * from "../src/entries/cli";
 /* #endregion */

--- a/tests/__snapshots__/dev/dev-entries/dist/index.ts.snap
+++ b/tests/__snapshots__/dev/dev-entries/dist/index.ts.snap
@@ -5,6 +5,12 @@ module.exports = require("../src/index.ts");
 /* #endregion */
 
 
+/* #region dist/index.d.mts */
+export * from "../src/index";
+export { default } from "../src/index";
+/* #endregion */
+
+
 /* #region dist/index.d.ts */
 export * from "../src/index";
 export { default } from "../src/index";

--- a/tests/__snapshots__/dev/dev-entries/dist/re-export.ts.snap
+++ b/tests/__snapshots__/dev/dev-entries/dist/re-export.ts.snap
@@ -5,6 +5,12 @@ module.exports = require("../src/entries/re-export.ts");
 /* #endregion */
 
 
+/* #region dist/re-export.d.mts */
+export * from "../src/entries/re-export";
+export { default } from "../src/entries/re-export";
+/* #endregion */
+
+
 /* #region dist/re-export.d.ts */
 export * from "../src/entries/re-export";
 export { default } from "../src/entries/re-export";

--- a/tests/__snapshots__/package/dts-compat/dist/index.ts.snap
+++ b/tests/__snapshots__/package/dts-compat/dist/index.ts.snap
@@ -6,6 +6,11 @@ exports.maybe = maybe;
 /* #endregion */
 
 
+/* #region dist/index.d.mts */
+export { Maybe, maybe } from './some/other/file.js';
+/* #endregion */
+
+
 /* #region dist/index.d.ts */
 export { Maybe, maybe } from './some/other/file.js';
 /* #endregion */

--- a/tests/__snapshots__/package/esm-compat/dist/index.ts.snap
+++ b/tests/__snapshots__/package/esm-compat/dist/index.ts.snap
@@ -36,6 +36,19 @@ exports.render = render;
 /* #endregion */
 
 
+/* #region dist/index.d.mts */
+export { default as cjsDirIndex } from 'autosuggest-highlight/parse';
+export { default as cjsFauxEsm } from 'react-keyed-flatten-children';
+export { default as scopedSubpath } from '@crackle-fixtures/dep-with-exports/subpath';
+export { default as scopedPatchedSubpath } from '@crackle-fixtures/dep-with-exports-always-patch/subpath';
+
+declare const App: React.FC;
+declare const render: () => string;
+
+export { App, render };
+/* #endregion */
+
+
 /* #region dist/index.d.ts */
 export { default as cjsDirIndex } from 'autosuggest-highlight/parse';
 export { default as cjsFauxEsm } from 'react-keyed-flatten-children';

--- a/tests/__snapshots__/package/library-with-docs/dist/index.ts.snap
+++ b/tests/__snapshots__/package/library-with-docs/dist/index.ts.snap
@@ -6,6 +6,19 @@ exports.JobSummary = styles_components_JobSummary_JobSummary_cjs.JobSummary;
 /* #endregion */
 
 
+/* #region dist/index.d.mts */
+import * as react_jsx_runtime from 'react/jsx-runtime';
+
+interface JobSummaryProps {
+    title: string;
+    isNew: boolean;
+}
+declare const JobSummary: ({ title, isNew }: JobSummaryProps) => react_jsx_runtime.JSX.Element;
+
+export { JobSummary };
+/* #endregion */
+
+
 /* #region dist/index.d.ts */
 import * as react_jsx_runtime from 'react/jsx-runtime';
 

--- a/tests/__snapshots__/package/multi-entry-library/dist/components.ts.snap
+++ b/tests/__snapshots__/package/multi-entry-library/dist/components.ts.snap
@@ -6,6 +6,11 @@ exports.JobSummary = JobSummary.JobSummary;
 /* #endregion */
 
 
+/* #region dist/components.d.mts */
+export { JobSummary } from './apac.chunk.js';
+/* #endregion */
+
+
 /* #region dist/components.d.ts */
 export { JobSummary } from './apac.chunk.js';
 /* #endregion */

--- a/tests/__snapshots__/package/multi-entry-library/dist/extras.ts.snap
+++ b/tests/__snapshots__/package/multi-entry-library/dist/extras.ts.snap
@@ -12,6 +12,11 @@ exports.logger = logger;
 /* #endregion */
 
 
+/* #region dist/extras.d.mts */
+export { DevDepType, calcAndLog, logger } from './apac.chunk.js';
+/* #endregion */
+
+
 /* #region dist/extras.d.ts */
 export { DevDepType, calcAndLog, logger } from './apac.chunk.js';
 /* #endregion */

--- a/tests/__snapshots__/package/multi-entry-library/dist/index.ts.snap
+++ b/tests/__snapshots__/package/multi-entry-library/dist/index.ts.snap
@@ -8,6 +8,11 @@ exports.add = add;
 /* #endregion */
 
 
+/* #region dist/index.d.mts */
+export { JobSummary, add } from './apac.chunk.js';
+/* #endregion */
+
+
 /* #region dist/index.d.ts */
 export { JobSummary, add } from './apac.chunk.js';
 /* #endregion */

--- a/tests/__snapshots__/package/multi-entry-library/dist/themes/apac.ts.snap
+++ b/tests/__snapshots__/package/multi-entry-library/dist/themes/apac.ts.snap
@@ -5,6 +5,11 @@ module.exports = apac;
 /* #endregion */
 
 
+/* #region dist/themes/apac.d.mts */
+export { _default as default } from '../apac.chunk.js';
+/* #endregion */
+
+
 /* #region dist/themes/apac.d.ts */
 export { _default as default } from '../apac.chunk.js';
 /* #endregion */

--- a/tests/__snapshots__/package/single-entry-library/dist/index.ts.snap
+++ b/tests/__snapshots__/package/single-entry-library/dist/index.ts.snap
@@ -11,6 +11,20 @@ Object.defineProperty(exports, "MultiJobSummary", {
 /* #endregion */
 
 
+/* #region dist/index.d.mts */
+import * as react_jsx_runtime from 'react/jsx-runtime';
+export { JobSummary as MultiJobSummary } from '@crackle-fixtures/multi-entry-library/components';
+
+interface JobSummaryProps {
+    title: string;
+    isNew: boolean;
+}
+declare const JobSummary: ({ title, isNew }: JobSummaryProps) => react_jsx_runtime.JSX.Element;
+
+export { JobSummary };
+/* #endregion */
+
+
 /* #region dist/index.d.ts */
 import * as react_jsx_runtime from 'react/jsx-runtime';
 export { JobSummary as MultiJobSummary } from '@crackle-fixtures/multi-entry-library/components';

--- a/tests/__snapshots__/package/with-dep-hidden-package-json/dist/index.ts.snap
+++ b/tests/__snapshots__/package/with-dep-hidden-package-json/dist/index.ts.snap
@@ -7,6 +7,11 @@ module.exports = hiddenPackageJson__default.default;
 /* #endregion */
 
 
+/* #region dist/index.d.mts */
+export { default } from '@crackle-fixtures/hidden-package-json';
+/* #endregion */
+
+
 /* #region dist/index.d.ts */
 export { default } from '@crackle-fixtures/hidden-package-json';
 /* #endregion */

--- a/tests/__snapshots__/package/with-graphql-schema-types/dist/index.ts.snap
+++ b/tests/__snapshots__/package/with-graphql-schema-types/dist/index.ts.snap
@@ -6,6 +6,15 @@ exports.maybe = maybe;
 /* #endregion */
 
 
+/* #region dist/index.d.mts */
+import { Maybe } from '@crackle-fixtures/graphql-schema/types';
+
+declare const maybe: Maybe<string>;
+
+export { maybe };
+/* #endregion */
+
+
 /* #region dist/index.d.ts */
 import { Maybe } from '@crackle-fixtures/graphql-schema/types';
 

--- a/tests/__snapshots__/package/with-side-effects/dist/css-more.ts.snap
+++ b/tests/__snapshots__/package/with-side-effects/dist/css-more.ts.snap
@@ -9,6 +9,11 @@ exports.atoms = styles_lib_atoms_atoms_cjs.atoms;
 /* #endregion */
 
 
+/* #region dist/css-more.d.mts */
+export { Breakpoint, atoms, breakpointNames, breakpoints } from './reset.chunk.js';
+/* #endregion */
+
+
 /* #region dist/css-more.d.ts */
 export { Breakpoint, atoms, breakpointNames, breakpoints } from './reset.chunk.js';
 /* #endregion */

--- a/tests/__snapshots__/package/with-side-effects/dist/css.ts.snap
+++ b/tests/__snapshots__/package/with-side-effects/dist/css.ts.snap
@@ -6,6 +6,11 @@ exports.atoms = styles_lib_atoms_atoms_cjs.atoms;
 /* #endregion */
 
 
+/* #region dist/css.d.mts */
+export { atoms } from './reset.chunk.js';
+/* #endregion */
+
+
 /* #region dist/css.d.ts */
 export { atoms } from './reset.chunk.js';
 /* #endregion */

--- a/tests/__snapshots__/package/with-side-effects/dist/index.ts.snap
+++ b/tests/__snapshots__/package/with-side-effects/dist/index.ts.snap
@@ -8,6 +8,11 @@ exports.Box = Box;
 /* #endregion */
 
 
+/* #region dist/index.d.mts */
+export { Box, BraidProvider } from './reset.chunk.js';
+/* #endregion */
+
+
 /* #region dist/index.d.ts */
 export { Box, BraidProvider } from './reset.chunk.js';
 /* #endregion */

--- a/tests/__snapshots__/package/with-side-effects/dist/reset.ts.snap
+++ b/tests/__snapshots__/package/with-side-effects/dist/reset.ts.snap
@@ -9,6 +9,12 @@ if (process.env.NODE_ENV === "development") {
 /* #endregion */
 
 
+/* #region dist/reset.d.mts */
+
+export {  }
+/* #endregion */
+
+
 /* #region dist/reset.d.ts */
 
 export {  }

--- a/tests/__snapshots__/package/with-styles/dist/index.ts.snap
+++ b/tests/__snapshots__/package/with-styles/dist/index.ts.snap
@@ -6,6 +6,15 @@ exports.Component = styles_Component_cjs.Component;
 /* #endregion */
 
 
+/* #region dist/index.d.mts */
+import * as react_jsx_runtime from 'react/jsx-runtime';
+
+declare const _default: () => react_jsx_runtime.JSX.Element;
+
+export { _default as Component };
+/* #endregion */
+
+
 /* #region dist/index.d.ts */
 import * as react_jsx_runtime from 'react/jsx-runtime';
 

--- a/tests/__snapshots__/package/with-vocab/dist/index.ts.snap
+++ b/tests/__snapshots__/package/with-vocab/dist/index.ts.snap
@@ -150,6 +150,13 @@ module.exports = client;
 /* #endregion */
 
 
+/* #region dist/index.d.mts */
+declare const _default: () => void;
+
+export { _default as default };
+/* #endregion */
+
+
 /* #region dist/index.d.ts */
 declare const _default: () => void;
 

--- a/tests/snapshot-output.ts
+++ b/tests/snapshot-output.ts
@@ -23,7 +23,7 @@ export default async function snapshotOutput(
     onlyFiles: true,
   });
   const groups = _.groupBy(distFiles, (fileName) =>
-    fileName.replace(/(.cjs|.mjs|.d.ts)$/, '.ts'),
+    fileName.replace(/(.cjs|.mjs|.d.ts|.d.mts)$/, '.ts'),
   );
 
   await promiseMap(Object.entries(groups), async ([groupName, files]) => {


### PR DESCRIPTION
Result: https://arethetypeswrong.github.io/?p=@crackle/cli@0.12.6

The warning: https://github.com/arethetypeswrong/arethetypeswrong.github.io/blob/main/docs/problems/FalseCJS.md

For both `crackle package` and `crackle dev` the `.d.mts` is a copy of the `.d.ts` file. This _just works_™ because Rollup generates code with ESM-compatible import specifiers i.e. `import { blah } from './foo/bar.js'`.

I chose `dtsm` as the new format name because it's a [portmanteau](https://en.wikipedia.org/wiki/Portmanteau) of `dts` and `esm`.