### PR TITLE
`crackle fix`: don't overwrite `package.json` if not needed

### DIFF
--- a/.changeset/core-fix-package.md
+++ b/.changeset/core-fix-package.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': patch
+---
+
+`crackle fix`: don't overwrite `package.json` if not needed

--- a/packages/core/src/entries/package.ts
+++ b/packages/core/src/entries/package.ts
@@ -2,8 +2,6 @@ import fs from 'fs/promises';
 import path from 'path';
 import process from 'process';
 
-import type { Rollup } from 'vite';
-
 import { type EnhancedConfig, type PartialConfig, getConfig } from '../config';
 import { distDir } from '../constants';
 import { createBundle } from '../package-utils/bundle';
@@ -87,13 +85,17 @@ const build = async (config: EnhancedConfig, packageName: string) => {
 
   await updateGitignore(config.root, entries);
 
-  const cssExports = (bundles as Rollup.RollupOutput[])
-    .flatMap((bundle) => bundle.output)
-    .map((output) => output.fileName)
-    .filter((fileName) => fileName.endsWith('.css'))
-    .map((fileName) => path.join(distDir, fileName));
+  const cssExports =
+    Array.isArray(bundles) &&
+    bundles
+      .flatMap((bundle) => bundle.output)
+      .map((output) => output.fileName)
+      .filter((fileName) => fileName.endsWith('.css'))
+      .map((fileName) => path.join(distDir, fileName));
 
-  await updatePackageJsonExports(config.root, cssExports);
+  if (cssExports && cssExports.length > 0) {
+    await updatePackageJsonExports(config.root, cssExports);
+  }
 
   logger.success(`Finished building \`${packageName}\`!`);
 };

--- a/packages/core/src/utils/setup-package-json.ts
+++ b/packages/core/src/utils/setup-package-json.ts
@@ -226,7 +226,7 @@ const setupPackageJson =
       entries,
     );
 
-    if (write) {
+    if (write && diffs.length > 0) {
       await writePackageJson({
         dir: packageRoot,
         contents: expectedPackageJson,
@@ -249,9 +249,7 @@ export const updatePackageJsonExports = async (
   const packageJson: PackageJson = await fse.readJson(packagePath, { fs });
 
   const packageExports = packageJson.exports as Exports;
-
-  const lastKey = Object.keys(packageExports).pop()!;
-  const lastExport = packageExports[lastKey];
+  const [lastKey, lastExport] = Object.entries(packageExports).pop()!;
 
   delete packageExports[lastKey];
   for (const entry of exports) {


### PR DESCRIPTION
If Crackle (or the user) has added more exports to `package.json`, don't overwrite the changes.

This changes is required for using Crackle in Capsize, where the [huge list of font metrics](https://unpkg.com/browse/@capsizecss/metrics@1.2.0/) needs to be exposed via user-defined [subpath patterns](https://nodejs.org/docs/latest-v20.x/api/packages.html#subpath-patterns).