### PR TITLE
Allow Renovate branches to be manually created

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,7 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["github>seek-oss/rynovate"],
-  "prCreation": "not-pending",
+  "prCreation": "immediate",
   "lockFileMaintenance": {
     "enabled": true,
     "schedule": ["before 8am on Monday"],


### PR DESCRIPTION
Right now we're not getting Renovate PRs, likely because commits are in a pending state waiting for a snapshot deployment. The docs are not clear about this, but it is what I'm observing.

The new setting makes PR creation [manual](https://docs.renovatebot.com/configuration-options/#prcreation):

> When `prCreation` is set to `approval`, Renovate creates the PR only when approved via the Dependency Dashboard. Renovate still creates the branch immediately.