### PR TITLE
Add repo metadata to `package.json` files

### DIFF
--- a/packages/babel-plugin-remove-exports/package.json
+++ b/packages/babel-plugin-remove-exports/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@crackle/babel-plugin-remove-exports",
   "version": "0.3.0",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seek-oss/crackle.git",
+    "directory": "packages/babel-plugin-remove-exports"
+  },
   "license": "MIT",
   "author": "SEEK",
   "sideEffects": false,

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@crackle/cli",
   "version": "0.15.3",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seek-oss/crackle.git",
+    "directory": "packages/cli"
+  },
   "license": "MIT",
   "author": "SEEK",
   "exports": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@crackle/core",
   "version": "0.33.2",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seek-oss/crackle.git",
+    "directory": "packages/core"
+  },
   "license": "MIT",
   "author": "SEEK",
   "sideEffects": false,

--- a/packages/router/package.json
+++ b/packages/router/package.json
@@ -1,6 +1,11 @@
 {
   "name": "@crackle/router",
   "version": "0.4.1",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/seek-oss/crackle.git",
+    "directory": "packages/router"
+  },
   "license": "MIT",
   "author": "SEEK",
   "sideEffects": false,


### PR DESCRIPTION
Repo metadata is shown on the npm package page and is used by renovate to fetch patch notes from changelog files.