### PR TITLE
Fix issue with newer versions of `rollup-plugin-node-externals`

### DIFF
--- a/.changeset/proud-candles-change.md
+++ b/.changeset/proud-candles-change.md
@@ -3,3 +3,5 @@
 ---
 
 Fix a bug caused by newer versions of `rollup-plugin-node-externals`
+
+We were assuming that `rollup-plugin-node-externals` hooks would always be functions, but they can be objects too. We now check for this at runtime.

--- a/.changeset/proud-candles-change.md
+++ b/.changeset/proud-candles-change.md
@@ -1,0 +1,5 @@
+---
+'@crackle/core': patch
+---
+
+Fix a bug caused by newer versions of `rollup-plugin-node-externals`

--- a/packages/core/src/plugins/rollup/externals.ts
+++ b/packages/core/src/plugins/rollup/externals.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import fse from 'fs-extra';
-import type { FunctionPluginHooks, Plugin, PluginHooks } from 'rollup';
+import type { Plugin } from 'rollup';
 import rollupExternals, {
   type ExternalsOptions,
 } from 'rollup-plugin-node-externals';
@@ -135,8 +135,17 @@ export function externals(
     name: `crackle:patched-${plugin.name}`,
 
     async buildStart(...args) {
+      if (!plugin.buildStart) {
+        throw new Error(
+          "Unable to find 'buildStart' hook in 'rollup-plugin-node-externals'",
+        );
+      }
+
+      const buildStartHook = plugin.buildStart;
+      const buildStartHandler =
+        'handler' in buildStartHook ? buildStartHook.handler : buildStartHook;
       await Promise.all([
-        (plugin as FunctionPluginHooks).buildStart.call(this, ...args),
+        buildStartHandler.call(this, ...args),
         findDependencies(options).then((result) => (packagesById = result)),
       ]);
     },
@@ -144,10 +153,21 @@ export function externals(
     resolveId: {
       order: 'pre',
       async handler(id, importer, hookOptions) {
-        const resolveIdHook = (plugin as PluginHooks).resolveId;
-        const handler =
+        if (!plugin.resolveId) {
+          throw new Error(
+            "Unable to find 'resolveId' hook in 'rollup-plugin-node-externals'",
+          );
+        }
+
+        const resolveIdHook = plugin.resolveId;
+        const resolveIdHandler =
           'handler' in resolveIdHook ? resolveIdHook.handler : resolveIdHook;
-        const resolved = await handler.call(this, id, importer, hookOptions);
+        const resolved = await resolveIdHandler.call(
+          this,
+          id,
+          importer,
+          hookOptions,
+        );
 
         if (
           (typeof resolved === 'boolean' && !resolved) ||

--- a/packages/core/src/plugins/rollup/externals.ts
+++ b/packages/core/src/plugins/rollup/externals.ts
@@ -1,7 +1,7 @@
 import path from 'path';
 
 import fse from 'fs-extra';
-import type { FunctionPluginHooks, Plugin } from 'rollup';
+import type { FunctionPluginHooks, Plugin, PluginHooks } from 'rollup';
 import rollupExternals, {
   type ExternalsOptions,
 } from 'rollup-plugin-node-externals';
@@ -144,12 +144,10 @@ export function externals(
     resolveId: {
       order: 'pre',
       async handler(id, importer, hookOptions) {
-        const resolved = await (plugin as FunctionPluginHooks).resolveId.call(
-          this,
-          id,
-          importer,
-          hookOptions,
-        );
+        const resolveIdHook = (plugin as PluginHooks).resolveId;
+        const handler =
+          'handler' in resolveIdHook ? resolveIdHook.handler : resolveIdHook;
+        const resolved = await handler.call(this, id, importer, hookOptions);
 
         if (
           (typeof resolved === 'boolean' && !resolved) ||


### PR DESCRIPTION
Since `rollup-plugin-node-externals@7.1.0`, [its `resolveId` hook is now an object, rather than just a function](https://github.com/Septh/rollup-plugin-node-externals/commit/5e9015be077a6e67a192906fd19a2692e8d1eea2#diff-fcd423a0b6ae0654240ee2c1cb0b023707df57b7d1c7a3834c5bfbef7d901da5R236-R238). I've added a runtime check for the `handler` field so we can support this change, while still being backwards compatible with older versions.

We have a dependency on `rollup-plugin-node-externals`, so we could just update it. However, this poses a problem in CI where we build crackle using the previous version of crackle. If we updated the dependency alongside the fix, CI would fail. So the fix needs to be released first, then we can bump the dependency. _But_, with the fix out, there's no need to bump the dependency anymore.