### PR TITLE
Use `workspace` protocol for internal dep to fix broken release step

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,0 @@
-prefer-workspace-packages=true

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -132,7 +132,7 @@
     "@babel/core": "^7.23.3",
     "@babel/plugin-syntax-jsx": "^7.23.3",
     "@babel/plugin-syntax-typescript": "^7.23.3",
-    "@crackle/babel-plugin-remove-exports": "^0.3.0",
+    "@crackle/babel-plugin-remove-exports": "workspace:^",
     "@crackle/router": "workspace:^",
     "@vanilla-extract/css": "^1.17.1",
     "@vanilla-extract/integration": "^8.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -397,8 +397,8 @@ importers:
         specifier: ^7.23.3
         version: 7.25.9(@babel/core@7.26.10)
       '@crackle/babel-plugin-remove-exports':
-        specifier: ^0.3.0
-        version: 0.3.0
+        specifier: workspace:^
+        version: link:../babel-plugin-remove-exports
       '@crackle/router':
         specifier: workspace:^
         version: link:../router


### PR DESCRIPTION
We should be using `workspace` versions for every crackle dep. There was one that was using an explicit version, which caused PNPM to try and fetch the new, not-yet-published version after running `changeset version`, resulting in [this error](https://github.com/seek-oss/crackle/actions/runs/13823265593/job/38673259469#step:3:34) in the most recent `master` build.