### PR TITLE
Update `rollup-plugin-dts` in an attempt to fix test flakiness

### DIFF
--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -154,7 +154,7 @@
     "react-dom": "^18.2.0",
     "resolve-from": "^5.0.0",
     "rollup": "^4.35.0",
-    "rollup-plugin-dts": "^6.1.0",
+    "rollup-plugin-dts": "^6.2.1",
     "rollup-plugin-node-externals": "^8.0.0",
     "semver": "^7.5.4",
     "serialize-javascript": "^6.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -472,8 +472,8 @@ importers:
         specifier: ^4.35.0
         version: 4.35.0
       rollup-plugin-dts:
-        specifier: ^6.1.0
-        version: 6.1.1(rollup@4.35.0)(typescript@5.8.2)
+        specifier: ^6.2.1
+        version: 6.2.1(rollup@4.35.0)(typescript@5.8.2)
       rollup-plugin-node-externals:
         specifier: ^8.0.0
         version: 8.0.0(rollup@4.35.0)
@@ -5280,8 +5280,8 @@ packages:
       rollup: ^3.0
       typescript: ^4.1 || ^5.0
 
-  rollup-plugin-dts@6.1.1:
-    resolution: {integrity: sha512-aSHRcJ6KG2IHIioYlvAOcEq6U99sVtqDDKVhnwt70rW6tsz3tv5OSjEiWcgzfsHdLyGXZ/3b/7b/+Za3Y6r1XA==}
+  rollup-plugin-dts@6.2.1:
+    resolution: {integrity: sha512-sR3CxYUl7i2CHa0O7bA45mCrgADyAQ0tVtGSqi3yvH28M+eg1+g5d7kQ9hLvEz5dorK3XVsH5L2jwHLQf72DzA==}
     engines: {node: '>=16'}
     peerDependencies:
       rollup: ^3.29.4 || ^4
@@ -6599,7 +6599,7 @@ snapshots:
       react-dom: 18.3.1(react@18.3.1)
       resolve-from: 5.0.0
       rollup: 4.35.0
-      rollup-plugin-dts: 6.1.1(rollup@4.35.0)(typescript@5.8.2)
+      rollup-plugin-dts: 6.2.1(rollup@4.35.0)(typescript@5.8.2)
       rollup-plugin-node-externals: 7.1.3(rollup@4.35.0)
       semver: 7.7.1
       serialize-javascript: 6.0.2
@@ -11468,7 +11468,7 @@ snapshots:
     optionalDependencies:
       '@babel/code-frame': 7.26.2
 
-  rollup-plugin-dts@6.1.1(rollup@4.35.0)(typescript@5.8.2):
+  rollup-plugin-dts@6.2.1(rollup@4.35.0)(typescript@5.8.2):
     dependencies:
       magic-string: 0.30.17
       rollup: 4.35.0

--- a/tests/__snapshots__/package/dts-preserve/dist/some/other/file.ts.snap
+++ b/tests/__snapshots__/package/dts-preserve/dist/some/other/file.ts.snap
@@ -2,5 +2,6 @@
 type Maybe = 'something' | 'other';
 declare const maybe: Maybe;
 
-export { type Maybe, maybe };
+export { maybe };
+export type { Maybe };
 /* #endregion */

--- a/tests/__snapshots__/package/multi-entry-library/dist/apac.chunk.ts.snap
+++ b/tests/__snapshots__/package/multi-entry-library/dist/apac.chunk.ts.snap
@@ -18,5 +18,6 @@ declare const calcAndLog: (a: number, b: number, fn: MathsFn) => void;
 
 declare const _default: "I am theme";
 
-export { type DevDepType, JobSummary, _default, add, calcAndLog, logger };
+export { JobSummary, _default, add, calcAndLog, logger };
+export type { DevDepType };
 /* #endregion */

--- a/tests/__snapshots__/package/package-preserve-dts-preserve/dist/some/other/file.ts.snap
+++ b/tests/__snapshots__/package/package-preserve-dts-preserve/dist/some/other/file.ts.snap
@@ -9,7 +9,8 @@ exports.maybe = maybe;
 type Maybe = 'something' | 'other';
 declare const maybe: Maybe;
 
-export { type Maybe, maybe };
+export { maybe };
+export type { Maybe };
 /* #endregion */
 
 

--- a/tests/__snapshots__/package/package-preserve/dist/index.ts.snap
+++ b/tests/__snapshots__/package/package-preserve/dist/index.ts.snap
@@ -16,7 +16,8 @@ declare const maybe: Maybe;
 
 declare const _default: () => react_jsx_runtime.JSX.Element;
 
-export { _default as Component, type Maybe, maybe };
+export { _default as Component, maybe };
+export type { Maybe };
 /* #endregion */
 
 
@@ -28,7 +29,8 @@ declare const maybe: Maybe;
 
 declare const _default: () => react_jsx_runtime.JSX.Element;
 
-export { _default as Component, type Maybe, maybe };
+export { _default as Component, maybe };
+export type { Maybe };
 /* #endregion */
 
 

--- a/tests/__snapshots__/package/with-side-effects/dist/reset.chunk.ts.snap
+++ b/tests/__snapshots__/package/with-side-effects/dist/reset.chunk.ts.snap
@@ -83,5 +83,6 @@ interface Atoms extends Sprinkles {
 }
 declare const atoms: ({ reset, ...rest }: Atoms) => string;
 
-export { Box, BraidProvider, type Breakpoint, atoms, breakpointNames, breakpoints };
+export { Box, BraidProvider, atoms, breakpointNames, breakpoints };
+export type { Breakpoint };
 /* #endregion */

--- a/tests/__snapshots__/package/with-side-effects/dist/reset.ts.snap
+++ b/tests/__snapshots__/package/with-side-effects/dist/reset.ts.snap
@@ -11,13 +11,13 @@ if (process.env.NODE_ENV === "development") {
 
 /* #region dist/reset.d.mts */
 
-export {  }
+export { };
 /* #endregion */
 
 
 /* #region dist/reset.d.ts */
 
-export {  }
+export { };
 /* #endregion */
 
 

--- a/tests/snapshot-output.ts
+++ b/tests/snapshot-output.ts
@@ -43,6 +43,7 @@ export default async function snapshotOutput(
     const snapshotDir = `__snapshots__/${suiteName}/${fixtureName}`;
     await expect(output).toMatchFileSnapshot(
       `${snapshotDir}/${groupName}.snap`,
+      `Failed to match snapshot for ${groupName}.snap`,
     );
   });
 }


### PR DESCRIPTION
The latest version of `rollup-plugin-dts` _seems_ to have more stable dts output, so hopefully it stops test errors like [this](https://github.com/seek-oss/crackle/actions/runs/14960945435/job/42022742339#step:6:142) from occurring.

Also added a custom snapshot error message to make it easier to locate the failing snapshot.